### PR TITLE
Fix Client State Conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,6 +407,7 @@ dependencies = [
 name = "beefy-light-client"
 version = "0.1.0"
 dependencies = [
+ "beefy-light-client-primitives",
  "beefy-primitives",
  "beefy-prover",
  "ckb-merkle-mountain-range",
@@ -420,7 +421,6 @@ dependencies = [
  "pallet-mmr",
  "pallet-mmr-rpc",
  "parity-scale-codec",
- "primitives",
  "rs_merkle",
  "serde_json",
  "sp-core 6.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27)",
@@ -432,6 +432,21 @@ dependencies = [
  "sp-trie 6.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27)",
  "subxt",
  "tokio",
+]
+
+[[package]]
+name = "beefy-light-client-primitives"
+version = "0.1.0"
+dependencies = [
+ "beefy-primitives",
+ "ckb-merkle-mountain-range",
+ "derive_more",
+ "light-client-common",
+ "parity-scale-codec",
+ "rs_merkle",
+ "sp-core 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-mmr-primitives",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27)",
 ]
 
 [[package]]
@@ -461,6 +476,7 @@ dependencies = [
 name = "beefy-prover"
 version = "0.1.0"
 dependencies = [
+ "beefy-light-client-primitives",
  "beefy-primitives",
  "color-eyre",
  "derive_more",
@@ -476,7 +492,6 @@ dependencies = [
  "pallet-mmr-rpc",
  "parity-scale-codec",
  "prettyplease",
- "primitives",
  "rs_merkle",
  "serde_json",
  "sp-core 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2435,6 +2450,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "beefy-light-client",
+ "beefy-light-client-primitives",
  "beefy-primitives",
  "beefy-prover",
  "bytes",
@@ -2447,7 +2463,6 @@ dependencies = [
  "light-client-common",
  "parity-scale-codec",
  "primitive-types",
- "primitives",
  "prost 0.10.4",
  "prost-build 0.11.1",
  "prost-types 0.10.1",
@@ -4550,21 +4565,6 @@ dependencies = [
  "impl-serde",
  "scale-info",
  "uint",
-]
-
-[[package]]
-name = "primitives"
-version = "0.1.0"
-dependencies = [
- "beefy-primitives",
- "ckb-merkle-mountain-range",
- "derive_more",
- "light-client-common",
- "parity-scale-codec",
- "rs_merkle",
- "sp-core 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-mmr-primitives",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27)",
 ]
 
 [[package]]

--- a/algorithms/beefy/Cargo.toml
+++ b/algorithms/beefy/Cargo.toml
@@ -27,7 +27,7 @@ beefy-primitives = { default-features = false, git = "https://github.com/parityt
 sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
 
 # local
-beefy-client-primitives = { package = "primitives", path = "primitives", default-features = false }
+beefy-light-client-primitives = { path = "primitives", default-features = false }
 light-client-common = { path = "../../light-clients/common", default-features = false }
 
 [dev-dependencies]
@@ -59,7 +59,7 @@ std = [
     "rs_merkle/std",
     "mmr-lib/std",
     "frame-support/std",
-    "beefy-client-primitives/std",
+    "beefy-light-client-primitives/std",
     "sp-trie/std",
     "light-client-common/std",
 ]

--- a/algorithms/beefy/primitives/Cargo.toml
+++ b/algorithms/beefy/primitives/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "primitives"
+name = "beefy-light-client-primitives"
 version = "0.1.0"
 edition = "2021"
 authors = ["Seun Lanlege <seunlanlege@gmail.com>", "David Salami <david.salami@gmail.com>"]

--- a/algorithms/beefy/prover/Cargo.toml
+++ b/algorithms/beefy/prover/Cargo.toml
@@ -42,5 +42,5 @@ serde_json = { version = "1.0.74" }
 pallet-mmr-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
 sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
 hex = { version = "0.4.3" }
-beefy-client-primitives = { package = "primitives", path = "../primitives" }
+beefy-light-client-primitives = {  path = "../primitives" }
 

--- a/algorithms/beefy/prover/src/helpers.rs
+++ b/algorithms/beefy/prover/src/helpers.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use crate::{error::Error, Crypto};
-use beefy_client_primitives::{MerkleHasher, SignatureWithAuthorityIndex};
+use beefy_light_client_primitives::{MerkleHasher, SignatureWithAuthorityIndex};
 use codec::{Decode, Encode};
 use frame_support::sp_runtime::traits::Convert;
 use jsonrpsee_core::client::Client;

--- a/algorithms/beefy/prover/src/lib.rs
+++ b/algorithms/beefy/prover/src/lib.rs
@@ -20,7 +20,7 @@ pub mod helpers;
 pub mod relay_chain_queries;
 pub mod runtime;
 
-use beefy_client_primitives::{
+use beefy_light_client_primitives::{
 	get_leaf_index_for_block_number, ClientState, HostFunctions, MerkleHasher, MmrUpdateProof,
 	ParachainHeader, PartialMmrLeaf, SignedCommitment,
 };

--- a/algorithms/beefy/prover/src/relay_chain_queries.rs
+++ b/algorithms/beefy/prover/src/relay_chain_queries.rs
@@ -17,7 +17,7 @@ use super::runtime;
 use crate::{
 	error::Error, runtime::api::runtime_types::polkadot_runtime_parachains::paras::ParaLifecycle,
 };
-use beefy_client_primitives::get_leaf_index_for_block_number;
+use beefy_light_client_primitives::get_leaf_index_for_block_number;
 use beefy_primitives::{SignedCommitment, VersionedFinalityProof};
 use codec::{Decode, Encode};
 use pallet_mmr_rpc::{LeafBatchProof, LeafProof};

--- a/algorithms/beefy/src/lib.rs
+++ b/algorithms/beefy/src/lib.rs
@@ -21,7 +21,7 @@ extern crate alloc;
 #[cfg(test)]
 mod tests;
 
-use beefy_client_primitives::{
+use beefy_light_client_primitives::{
 	error::BeefyClientError, get_leaf_index_for_block_number, BeefyNextAuthoritySet, ClientState,
 	HostFunctions, MerkleHasher, MmrUpdateProof, NodesUtils, ParachainsUpdateProof,
 	SignatureWithAuthorityIndex, HASH_LENGTH,

--- a/algorithms/beefy/src/tests.rs
+++ b/algorithms/beefy/src/tests.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use beefy_client_primitives::{
+use beefy_light_client_primitives::{
 	error::BeefyClientError, MmrUpdateProof, ParachainsUpdateProof, SignatureWithAuthorityIndex,
 	SignedCommitment,
 };

--- a/light-clients/ics07-tendermint/src/client_state.rs
+++ b/light-clients/ics07-tendermint/src/client_state.rs
@@ -258,10 +258,6 @@ where
 		self.latest_height()
 	}
 
-	fn is_frozen(&self) -> bool {
-		todo!()
-	}
-
 	fn frozen_height(&self) -> Option<Height> {
 		self.frozen_height()
 	}

--- a/light-clients/ics10-grandpa/src/proto/grandpa.proto
+++ b/light-clients/ics10-grandpa/src/proto/grandpa.proto
@@ -41,7 +41,7 @@ message ClientState {
   uint64 current_set_id = 2;
 
   // Block height when the client was frozen due to a misbehaviour
-  uint64 frozen_height = 3;
+  optional uint64 frozen_height = 3;
 
   // Known relay chains
   RelayChain relay_chain = 4;

--- a/light-clients/ics11-beefy/Cargo.toml
+++ b/light-clients/ics11-beefy/Cargo.toml
@@ -13,7 +13,7 @@ std = [
     "ibc/std",
     "ibc-proto/std",
     "beefy-client/std",
-    "beefy-client-primitives/std",
+    "beefy-light-client-primitives/std",
     "light-client-common/std",
     "pallet-mmr-primitives/std",
     "beefy-primitives/std",
@@ -40,7 +40,7 @@ ibc-proto = { git = "https://github.com/ComposableFi/ibc-rs", rev = "9a959faabb8
 
 # beefy deps
 beefy-client = { package = "beefy-light-client", path = "../../algorithms/beefy",  default-features = false }
-beefy-client-primitives = { package = "primitives", path = "../../algorithms/beefy/primitives", default-features = false }
+beefy-light-client-primitives = {  path = "../../algorithms/beefy/primitives", default-features = false }
 light-client-common = { path = "../common", default-features = false }
 
 # substrate deps

--- a/light-clients/ics11-beefy/src/client_def.rs
+++ b/light-clients/ics11-beefy/src/client_def.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use beefy_client_primitives::{
+use beefy_light_client_primitives::{
 	ClientState as LightClientState, ParachainHeader, ParachainsUpdateProof,
 };
 use codec::{Decode, Encode};
@@ -60,7 +60,7 @@ pub struct BeefyClient<T>(PhantomData<T>);
 
 impl<H> ClientDef for BeefyClient<H>
 where
-	H: light_client_common::HostFunctions + beefy_client_primitives::HostFunctions,
+	H: light_client_common::HostFunctions + beefy_light_client_primitives::HostFunctions,
 {
 	type ClientMessage = ClientMessage;
 	type ClientState = ClientState<H>;

--- a/light-clients/ics11-beefy/src/client_message.rs
+++ b/light-clients/ics11-beefy/src/client_message.rs
@@ -27,7 +27,7 @@ use crate::{
 };
 use alloc::{format, vec, vec::Vec};
 use anyhow::anyhow;
-use beefy_client_primitives::{
+use beefy_light_client_primitives::{
 	BeefyNextAuthoritySet, Hash, MmrUpdateProof, PartialMmrLeaf, SignatureWithAuthorityIndex,
 	SignedCommitment,
 };

--- a/light-clients/ics11-beefy/src/error.rs
+++ b/light-clients/ics11-beefy/src/error.rs
@@ -26,7 +26,7 @@ use prost::DecodeError;
 #[derive(Debug, derive_more::From, derive_more::Display)]
 pub enum Error {
 	Codec(codec::Error),
-	Beefy(beefy_client_primitives::error::BeefyClientError),
+	Beefy(beefy_light_client_primitives::error::BeefyClientError),
 	TimeStamp(TimestampOverflowError),
 	ParseTimeStamp(ParseTimestampError),
 	ValidationError(ValidationError),

--- a/light-clients/ics11-beefy/src/mock.rs
+++ b/light-clients/ics11-beefy/src/mock.rs
@@ -52,7 +52,7 @@ pub const MOCK_CONSENSUS_STATE_TYPE_URL: &str = "/ibc.mock.ConsensusState";
 #[derive(Clone, Default, PartialEq, Debug, Eq)]
 pub struct HostFunctionsManager;
 
-impl beefy_client_primitives::HostFunctions for HostFunctionsManager {
+impl beefy_light_client_primitives::HostFunctions for HostFunctionsManager {
 	fn keccak_256(input: &[u8]) -> [u8; 32] {
 		beefy_prover::Crypto::keccak_256(input)
 	}

--- a/light-clients/ics11-beefy/src/proto/beefy.proto
+++ b/light-clients/ics11-beefy/src/proto/beefy.proto
@@ -35,7 +35,7 @@ message ClientState {
   uint32 latest_beefy_height = 2;
 
   // Block height when the client was frozen due to a misbehaviour
-  uint64 frozen_height = 3;
+  optional uint64 frozen_height = 3;
 
   /// Known relay chains
   RelayChain relay_chain = 4;

--- a/light-clients/ics11-beefy/src/tests.rs
+++ b/light-clients/ics11-beefy/src/tests.rs
@@ -24,7 +24,7 @@ use crate::{
 		AnyClientMessage, AnyClientState, AnyConsensusState, HostFunctionsManager, MockClientTypes,
 	},
 };
-use beefy_client_primitives::{NodesUtils, PartialMmrLeaf};
+use beefy_light_client_primitives::{NodesUtils, PartialMmrLeaf};
 use beefy_prover::{
 	helpers::{fetch_timestamp_extrinsic_with_proof, TimeStampExtWithProof},
 	runtime, ClientWrapper,

--- a/light-clients/ics13-near/src/client_state.rs
+++ b/light-clients/ics13-near/src/client_state.rs
@@ -80,10 +80,6 @@ impl<H: HostFunctionsTrait> ClientState for NearClientState<H> {
 		self.head.get_height()
 	}
 
-	fn is_frozen(&self) -> bool {
-		self.frozen_height().is_some()
-	}
-
 	fn frozen_height(&self) -> Option<Height> {
 		// TODO: validate this
 		Some(self.head.get_height())


### PR DESCRIPTION
Make frozen height optional in proto files.
Rename `primitives` to `beefy-light-client-primitives`