### PR TITLE
commuincate that we're moving the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+Note: `centauri` moved to the [composable](https://github.com/ComposableFi/composable) mono repo.
 #  composable-bridge-common
 
 A set of crates that power composable's trustless bridge infrastructure.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-Note: `centauri` moved to the [composable](https://github.com/ComposableFi/composable) mono repo.
+> **Note**
+> `centauri` moved to the [composable](https://github.com/ComposableFi/composable) mono repo.
 #  composable-bridge-common
 
 A set of crates that power composable's trustless bridge infrastructure.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 > **Note**
+>
 > `centauri` moved to the [composable](https://github.com/ComposableFi/composable) mono repo.
 #  composable-bridge-common
 


### PR DESCRIPTION
Add a note into the README to let people know that this repo has moved to our [monorepo](https://github.com/ComposableFi/composable)