### PR TITLE
Cosmos<>Cosmos through Hyperspace as a groundwork for Comsos<>Parachain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ dependencies = [
  "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27)",
  "sp-trie",
- "subxt",
+ "subxt 0.24.0 (git+https://github.com/paritytech/subxt?rev=1736f618d940a69ab212a686984c3be25b08d1c2)",
  "tokio",
 ]
 
@@ -678,7 +678,7 @@ dependencies = [
  "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27)",
  "sp-trie",
- "subxt",
+ "subxt 0.24.0 (git+https://github.com/paritytech/subxt?rev=1736f618d940a69ab212a686984c3be25b08d1c2)",
  "subxt-generated",
  "tokio",
 ]
@@ -1222,7 +1222,7 @@ dependencies = [
  "hex",
  "jsonrpsee 0.14.0",
  "parity-scale-codec",
- "subxt-codegen",
+ "subxt-codegen 0.24.0 (git+https://github.com/paritytech/subxt?rev=1736f618d940a69ab212a686984c3be25b08d1c2)",
  "syn",
  "tokio",
 ]
@@ -3300,7 +3300,7 @@ dependencies = [
  "sp-state-machine",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27)",
  "sp-trie",
- "subxt",
+ "subxt 0.24.0 (git+https://github.com/paritytech/subxt?rev=1736f618d940a69ab212a686984c3be25b08d1c2)",
  "tokio",
 ]
 
@@ -3328,7 +3328,7 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-trie",
- "subxt",
+ "subxt 0.24.0 (git+https://github.com/paritytech/subxt?rev=1736f618d940a69ab212a686984c3be25b08d1c2)",
  "subxt-generated",
  "tokio",
 ]
@@ -3710,7 +3710,7 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-trie",
- "subxt",
+ "subxt 0.24.0 (git+https://github.com/paritytech/subxt?rev=1736f618d940a69ab212a686984c3be25b08d1c2)",
  "tendermint-proto",
  "thiserror",
  "tokio",
@@ -3736,7 +3736,9 @@ dependencies = [
  "pallet-ibc",
  "parity-scale-codec",
  "serde",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27)",
  "ss58-registry",
+ "subxt 0.24.0 (git+https://github.com/paritytech/subxt?rev=51179a8b72472d0b43c91cda75a1ddc3fddb9555)",
  "tendermint",
  "tendermint-proto",
  "tendermint-rpc",
@@ -3819,7 +3821,7 @@ dependencies = [
  "sp-state-machine",
  "sp-trie",
  "ss58-registry",
- "subxt",
+ "subxt 0.24.0 (git+https://github.com/paritytech/subxt?rev=1736f618d940a69ab212a686984c3be25b08d1c2)",
  "subxt-generated",
  "tendermint-proto",
  "thiserror",
@@ -3841,7 +3843,7 @@ dependencies = [
  "log",
  "pallet-ibc",
  "parity-scale-codec",
- "subxt",
+ "subxt 0.24.0 (git+https://github.com/paritytech/subxt?rev=1736f618d940a69ab212a686984c3be25b08d1c2)",
  "thiserror",
  "tokio",
 ]
@@ -3854,6 +3856,7 @@ dependencies = [
  "async-trait",
  "futures",
  "hyperspace-core",
+ "hyperspace-cosmos",
  "hyperspace-primitives",
  "ibc",
  "ibc-proto",
@@ -3864,7 +3867,7 @@ dependencies = [
  "sp-keyring",
  "sp-keystore",
  "sp-runtime",
- "subxt",
+ "subxt 0.24.0 (git+https://github.com/paritytech/subxt?rev=1736f618d940a69ab212a686984c3be25b08d1c2)",
  "tendermint-proto",
  "tendermint-rpc",
  "tokio",
@@ -4087,7 +4090,7 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-trie",
- "subxt",
+ "subxt 0.24.0 (git+https://github.com/paritytech/subxt?rev=1736f618d940a69ab212a686984c3be25b08d1c2)",
  "tendermint",
  "tendermint-proto",
  "tokio",
@@ -4123,7 +4126,7 @@ dependencies = [
  "sp-state-machine",
  "sp-storage 6.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27)",
  "sp-trie",
- "subxt",
+ "subxt 0.24.0 (git+https://github.com/paritytech/subxt?rev=1736f618d940a69ab212a686984c3be25b08d1c2)",
  "tendermint",
  "tendermint-proto",
  "tokio",
@@ -12571,8 +12574,34 @@ dependencies = [
  "serde_json",
  "sp-core 6.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27)",
  "sp-runtime",
- "subxt-macro",
- "subxt-metadata",
+ "subxt-macro 0.24.0 (git+https://github.com/paritytech/subxt?rev=1736f618d940a69ab212a686984c3be25b08d1c2)",
+ "subxt-metadata 0.24.0 (git+https://github.com/paritytech/subxt?rev=1736f618d940a69ab212a686984c3be25b08d1c2)",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "subxt"
+version = "0.24.0"
+source = "git+https://github.com/paritytech/subxt?rev=51179a8b72472d0b43c91cda75a1ddc3fddb9555#51179a8b72472d0b43c91cda75a1ddc3fddb9555"
+dependencies = [
+ "bitvec",
+ "derivative",
+ "frame-metadata",
+ "futures",
+ "hex",
+ "jsonrpsee 0.15.1",
+ "parity-scale-codec",
+ "parking_lot 0.12.1",
+ "scale-decode",
+ "scale-info",
+ "scale-value",
+ "serde",
+ "serde_json",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27)",
+ "sp-runtime",
+ "subxt-macro 0.24.0 (git+https://github.com/paritytech/subxt?rev=51179a8b72472d0b43c91cda75a1ddc3fddb9555)",
+ "subxt-metadata 0.24.0 (git+https://github.com/paritytech/subxt?rev=51179a8b72472d0b43c91cda75a1ddc3fddb9555)",
  "thiserror",
  "tracing",
 ]
@@ -12592,9 +12621,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scale-info",
- "subxt-metadata",
+ "subxt-metadata 0.24.0 (git+https://github.com/paritytech/subxt?rev=1736f618d940a69ab212a686984c3be25b08d1c2)",
  "syn",
  "tokio",
+]
+
+[[package]]
+name = "subxt-codegen"
+version = "0.24.0"
+source = "git+https://github.com/paritytech/subxt?rev=51179a8b72472d0b43c91cda75a1ddc3fddb9555#51179a8b72472d0b43c91cda75a1ddc3fddb9555"
+dependencies = [
+ "darling",
+ "frame-metadata",
+ "heck",
+ "parity-scale-codec",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "scale-info",
+ "subxt-metadata 0.24.0 (git+https://github.com/paritytech/subxt?rev=51179a8b72472d0b43c91cda75a1ddc3fddb9555)",
+ "syn",
 ]
 
 [[package]]
@@ -12602,7 +12648,7 @@ name = "subxt-generated"
 version = "0.1.0"
 dependencies = [
  "parity-scale-codec",
- "subxt",
+ "subxt 0.24.0 (git+https://github.com/paritytech/subxt?rev=1736f618d940a69ab212a686984c3be25b08d1c2)",
 ]
 
 [[package]]
@@ -12612,7 +12658,18 @@ source = "git+https://github.com/paritytech/subxt?rev=1736f618d940a69ab212a68698
 dependencies = [
  "darling",
  "proc-macro-error",
- "subxt-codegen",
+ "subxt-codegen 0.24.0 (git+https://github.com/paritytech/subxt?rev=1736f618d940a69ab212a686984c3be25b08d1c2)",
+ "syn",
+]
+
+[[package]]
+name = "subxt-macro"
+version = "0.24.0"
+source = "git+https://github.com/paritytech/subxt?rev=51179a8b72472d0b43c91cda75a1ddc3fddb9555#51179a8b72472d0b43c91cda75a1ddc3fddb9555"
+dependencies = [
+ "darling",
+ "proc-macro-error",
+ "subxt-codegen 0.24.0 (git+https://github.com/paritytech/subxt?rev=51179a8b72472d0b43c91cda75a1ddc3fddb9555)",
  "syn",
 ]
 
@@ -12620,6 +12677,17 @@ dependencies = [
 name = "subxt-metadata"
 version = "0.24.0"
 source = "git+https://github.com/paritytech/subxt?rev=1736f618d940a69ab212a686984c3be25b08d1c2#1736f618d940a69ab212a686984c3be25b08d1c2"
+dependencies = [
+ "frame-metadata",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27)",
+]
+
+[[package]]
+name = "subxt-metadata"
+version = "0.24.0"
+source = "git+https://github.com/paritytech/subxt?rev=51179a8b72472d0b43c91cda75a1ddc3fddb9555#51179a8b72472d0b43c91cda75a1ddc3fddb9555"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3694,6 +3694,7 @@ dependencies = [
  "ibc",
  "ibc-proto",
  "ibc-rpc",
+ "ics07-tendermint",
  "ics10-grandpa",
  "ics11-beefy",
  "light-client-common",
@@ -3719,6 +3720,29 @@ dependencies = [
 [[package]]
 name = "hyperspace-cosmos"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "env_logger",
+ "futures",
+ "hyperspace-primitives",
+ "ibc",
+ "ibc-proto",
+ "ibc-rpc",
+ "ics07-tendermint",
+ "jsonrpsee 0.15.1",
+ "jsonrpsee-ws-client 0.14.0",
+ "log",
+ "pallet-ibc",
+ "parity-scale-codec",
+ "serde",
+ "ss58-registry",
+ "tendermint",
+ "tendermint-proto",
+ "tendermint-rpc",
+ "thiserror",
+ "tonic",
+]
 
 [[package]]
 name = "hyperspace-metrics"
@@ -3830,7 +3854,6 @@ dependencies = [
  "async-trait",
  "futures",
  "hyperspace-core",
- "hyperspace-parachain",
  "hyperspace-primitives",
  "ibc",
  "ibc-proto",
@@ -3843,7 +3866,9 @@ dependencies = [
  "sp-runtime",
  "subxt",
  "tendermint-proto",
+ "tendermint-rpc",
  "tokio",
+ "tonic",
 ]
 
 [[package]]
@@ -13095,7 +13120,10 @@ dependencies = [
  "pin-project",
  "prost 0.10.4",
  "prost-derive 0.10.1",
+ "rustls-native-certs 0.6.2",
+ "rustls-pemfile",
  "tokio",
+ "tokio-rustls 0.23.4",
  "tokio-stream",
  "tokio-util",
  "tower",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d78656ba01f1b93024b7c3a0467f1608e4be67d725749fdcd7d2c7678fd7a2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-std"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,6 +1306,17 @@ name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "contracts"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d1429e3bd78171c65aa010eabcdf8f863ba3254728dbfb0ad4b1545beac15c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "convert_case"
@@ -2723,6 +2745,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.10.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "pin-project",
+ "spin 0.9.4",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3748,7 +3782,7 @@ dependencies = [
  "sp-state-machine",
  "sp-trie",
  "subxt 0.24.0 (git+https://github.com/paritytech/subxt?rev=1736f618d940a69ab212a686984c3be25b08d1c2)",
- "tendermint-proto",
+ "tendermint-proto 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
  "thiserror",
  "tokio",
  "toml",
@@ -3780,9 +3814,14 @@ dependencies = [
  "sp-core 6.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27)",
  "ss58-registry",
  "subxt 0.24.0 (git+https://github.com/paritytech/subxt?rev=51179a8b72472d0b43c91cda75a1ddc3fddb9555)",
- "tendermint",
- "tendermint-proto",
+ "tendermint 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
+ "tendermint-light-client",
+ "tendermint-light-client-verifier",
+ "tendermint-primitives",
+ "tendermint-proto 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
+ "tendermint-prover",
  "tendermint-rpc",
+ "tendermint-verifier",
  "thiserror",
  "tonic",
 ]
@@ -3798,7 +3837,7 @@ dependencies = [
  "ibc-proto",
  "log",
  "prometheus",
- "tendermint-proto",
+ "tendermint-proto 0.24.0-pre.2 (git+https://github.com/composableFi/tendermint-rs?rev=5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8)",
  "thiserror",
  "tokio",
 ]
@@ -3864,7 +3903,7 @@ dependencies = [
  "ss58-registry",
  "subxt 0.24.0 (git+https://github.com/paritytech/subxt?rev=1736f618d940a69ab212a686984c3be25b08d1c2)",
  "subxt-generated",
- "tendermint-proto",
+ "tendermint-proto 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -3909,7 +3948,7 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "subxt 0.24.0 (git+https://github.com/paritytech/subxt?rev=1736f618d940a69ab212a686984c3be25b08d1c2)",
- "tendermint-proto",
+ "tendermint-proto 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
  "tendermint-rpc",
  "tokio",
  "tonic",
@@ -3963,8 +4002,8 @@ dependencies = [
  "sp-core 6.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24)",
  "subtle-encoding",
- "tendermint",
- "tendermint-proto",
+ "tendermint 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
+ "tendermint-proto 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
  "test-log",
  "time 0.3.16",
  "tokio",
@@ -4015,7 +4054,7 @@ dependencies = [
  "prost 0.10.4",
  "schemars",
  "serde",
- "tendermint-proto",
+ "tendermint-proto 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
  "tonic",
 ]
 
@@ -4054,7 +4093,7 @@ dependencies = [
  "sp-core 6.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27)",
  "sp-runtime",
  "sp-trie",
- "tendermint-proto",
+ "tendermint-proto 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
 ]
 
 [[package]]
@@ -4086,9 +4125,9 @@ dependencies = [
  "serde_json",
  "sha2 0.10.6",
  "subtle-encoding",
- "tendermint",
+ "tendermint 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
  "tendermint-light-client-verifier",
- "tendermint-proto",
+ "tendermint-proto 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
  "tendermint-rpc",
  "tendermint-testgen",
  "test-log",
@@ -4132,8 +4171,8 @@ dependencies = [
  "sp-state-machine",
  "sp-trie",
  "subxt 0.24.0 (git+https://github.com/paritytech/subxt?rev=1736f618d940a69ab212a686984c3be25b08d1c2)",
- "tendermint",
- "tendermint-proto",
+ "tendermint 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
+ "tendermint-proto 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
  "tokio",
 ]
 
@@ -4168,8 +4207,8 @@ dependencies = [
  "sp-storage 6.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27)",
  "sp-trie",
  "subxt 0.24.0 (git+https://github.com/paritytech/subxt?rev=1736f618d940a69ab212a686984c3be25b08d1c2)",
- "tendermint",
- "tendermint-proto",
+ "tendermint 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
+ "tendermint-proto 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
  "tokio",
 ]
 
@@ -4199,8 +4238,8 @@ dependencies = [
  "sha3 0.10.6",
  "sp-core 6.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.24)",
  "subtle-encoding",
- "tendermint",
- "tendermint-proto",
+ "tendermint 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
+ "tendermint-proto 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
  "tendermint-rpc",
  "tendermint-testgen",
  "test-log",
@@ -4711,6 +4750,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "sec1",
+ "sha2 0.9.9",
 ]
 
 [[package]]
@@ -6773,9 +6813,9 @@ dependencies = [
  "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27)",
  "sp-trie",
- "tendermint",
+ "tendermint 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
  "tendermint-light-client-verifier",
- "tendermint-proto",
+ "tendermint-proto 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
 ]
 
 [[package]]
@@ -9575,7 +9615,7 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
+ "spin 0.5.2",
  "untrusted",
  "web-sys",
  "winapi",
@@ -11423,7 +11463,7 @@ dependencies = [
  "bytes",
  "ics23",
  "sha2 0.10.6",
- "tendermint",
+ "tendermint 0.24.0-pre.2 (git+https://github.com/composableFi/tendermint-rs?rev=5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8)",
 ]
 
 [[package]]
@@ -12391,6 +12431,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spin"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "ss58-registry"
 version = "1.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12847,7 +12896,37 @@ dependencies = [
  "signature",
  "subtle",
  "subtle-encoding",
- "tendermint-proto",
+ "tendermint-proto 0.24.0-pre.2 (git+https://github.com/composableFi/tendermint-rs?rev=5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8)",
+ "time 0.3.16",
+ "zeroize",
+]
+
+[[package]]
+name = "tendermint"
+version = "0.24.0-pre.2"
+source = "git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426#ab7db0fa89e1634ad9855bc567ba02d9e8916426"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "ed25519",
+ "ed25519-consensus",
+ "flex-error",
+ "futures",
+ "k256",
+ "num-traits",
+ "once_cell",
+ "prost 0.10.4",
+ "prost-types 0.10.1",
+ "ripemd",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "serde_repr",
+ "sha2 0.10.6",
+ "signature",
+ "subtle",
+ "subtle-encoding",
+ "tendermint-proto 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
  "time 0.3.16",
  "zeroize",
 ]
@@ -12855,26 +12934,69 @@ dependencies = [
 [[package]]
 name = "tendermint-config"
 version = "0.24.0-pre.2"
-source = "git+https://github.com/composableFi/tendermint-rs?rev=5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8#5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8"
+source = "git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426#ab7db0fa89e1634ad9855bc567ba02d9e8916426"
 dependencies = [
  "flex-error",
  "serde",
  "serde_json",
- "tendermint",
+ "tendermint 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
  "toml",
  "url",
 ]
 
 [[package]]
+name = "tendermint-light-client"
+version = "0.24.0-pre.2"
+source = "git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426#ab7db0fa89e1634ad9855bc567ba02d9e8916426"
+dependencies = [
+ "async-recursion",
+ "async-trait",
+ "contracts",
+ "derive_more",
+ "flex-error",
+ "flume",
+ "futures",
+ "futures-timer",
+ "serde",
+ "serde_derive",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27)",
+ "static_assertions",
+ "tendermint 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
+ "tendermint-light-client-verifier",
+ "tendermint-rpc",
+ "time 0.3.16",
+ "tokio",
+]
+
+[[package]]
 name = "tendermint-light-client-verifier"
 version = "0.24.0-pre.2"
-source = "git+https://github.com/composableFi/tendermint-rs?rev=5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8#5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8"
+source = "git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426#ab7db0fa89e1634ad9855bc567ba02d9e8916426"
 dependencies = [
  "derive_more",
  "flex-error",
  "serde",
- "tendermint",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27)",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27)",
+ "tendermint 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
  "time 0.3.16",
+]
+
+[[package]]
+name = "tendermint-primitives"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "derive_more",
+ "ibc",
+ "ibc-proto",
+ "ics07-tendermint",
+ "pallet-ibc",
+ "tendermint 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
+ "tendermint-light-client",
+ "tendermint-light-client-verifier",
+ "tendermint-proto 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
+ "tendermint-rpc",
 ]
 
 [[package]]
@@ -12895,9 +13017,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tendermint-proto"
+version = "0.24.0-pre.2"
+source = "git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426#ab7db0fa89e1634ad9855bc567ba02d9e8916426"
+dependencies = [
+ "bytes",
+ "flex-error",
+ "num-derive",
+ "num-traits",
+ "prost 0.10.4",
+ "prost-types 0.10.1",
+ "serde",
+ "serde_bytes",
+ "subtle-encoding",
+ "time 0.3.16",
+]
+
+[[package]]
+name = "tendermint-prover"
+version = "0.1.0"
+dependencies = [
+ "ibc",
+ "ibc-proto",
+ "tendermint 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
+ "tendermint-light-client",
+ "tendermint-light-client-verifier",
+ "tendermint-proto 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
+ "tendermint-rpc",
+]
+
+[[package]]
 name = "tendermint-rpc"
 version = "0.24.0-pre.2"
-source = "git+https://github.com/composableFi/tendermint-rs?rev=5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8#5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8"
+source = "git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426#ab7db0fa89e1634ad9855bc567ba02d9e8916426"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -12916,9 +13068,9 @@ dependencies = [
  "serde_json",
  "subtle",
  "subtle-encoding",
- "tendermint",
+ "tendermint 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
  "tendermint-config",
- "tendermint-proto",
+ "tendermint-proto 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
  "thiserror",
  "time 0.3.16",
  "tokio",
@@ -12931,7 +13083,7 @@ dependencies = [
 [[package]]
 name = "tendermint-testgen"
 version = "0.24.0-pre.2"
-source = "git+https://github.com/composableFi/tendermint-rs?rev=5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8#5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8"
+source = "git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426#ab7db0fa89e1634ad9855bc567ba02d9e8916426"
 dependencies = [
  "ed25519-consensus",
  "gumdrop",
@@ -12939,8 +13091,25 @@ dependencies = [
  "serde_json",
  "simple-error",
  "tempfile",
- "tendermint",
+ "tendermint 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
  "time 0.3.16",
+]
+
+[[package]]
+name = "tendermint-verifier"
+version = "0.1.0"
+dependencies = [
+ "futures-util",
+ "ibc",
+ "ibc-proto",
+ "ics07-tendermint",
+ "pallet-ibc",
+ "tendermint 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
+ "tendermint-light-client",
+ "tendermint-light-client-verifier",
+ "tendermint-primitives",
+ "tendermint-proto 0.24.0-pre.2 (git+https://github.com/farhad-shabani/tendermint-rs?rev=ab7db0fa89e1634ad9855bc567ba02d9e8916426)",
+ "tendermint-rpc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,6 +519,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,6 +721,27 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
+]
+
+[[package]]
+name = "bitcoin"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0694ea59225b0c5f3cb405ff3f670e4828358ed26aec49dc352f730f0cb1a8a3"
+dependencies = [
+ "bech32",
+ "bitcoin_hashes",
+ "secp256k1 0.24.1",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2268,6 +2295,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3723,6 +3760,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bech32",
+ "bitcoin",
+ "dirs-next",
  "env_logger",
  "futures",
  "hyperspace-primitives",
@@ -3736,6 +3776,7 @@ dependencies = [
  "pallet-ibc",
  "parity-scale-codec",
  "serde",
+ "serde_json",
  "sp-core 6.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27)",
  "ss58-registry",
  "subxt 0.24.0 (git+https://github.com/paritytech/subxt?rev=51179a8b72472d0b43c91cda75a1ddc3fddb9555)",
@@ -11080,7 +11121,9 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff55dc09d460954e9ef2fa8a7ced735a964be9981fd50e870b2b3b0705e14964"
 dependencies = [
+ "bitcoin_hashes",
  "secp256k1-sys 0.6.1",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,6 +530,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64ct"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
+
+[[package]]
 name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3806,9 +3812,11 @@ dependencies = [
  "ics07-tendermint",
  "jsonrpsee 0.15.1",
  "jsonrpsee-ws-client 0.14.0",
+ "k256",
  "log",
  "pallet-ibc",
  "parity-scale-codec",
+ "prost 0.10.4",
  "serde",
  "serde_json",
  "sp-core 6.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.27)",
@@ -7821,6 +7829,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs8"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
+dependencies = [
+ "der",
+ "spki",
+ "zeroize",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11142,6 +11161,7 @@ checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
 dependencies = [
  "der",
  "generic-array 0.14.6",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -12437,6 +12457,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]

--- a/algorithms/tendermint/README.md
+++ b/algorithms/tendermint/README.md
@@ -1,0 +1,1 @@
+# Tendermint Light Client

--- a/algorithms/tendermint/primitives/Cargo.toml
+++ b/algorithms/tendermint/primitives/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "tendermint-primitives"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+# crates.io
+anyhow = { version = "1.0.64", default-features = false }
+derive_more = { version = "0.99.17", default-features = false, features = ["display"] }
+
+# ibc
+ibc = { path = "../../../ibc/modules", features = [] }
+ibc-proto = { path = "../../../ibc/proto" }
+pallet-ibc = { path = "../../../../parachain/frame/ibc" }
+
+# Tendermint
+tendermint = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", default-features = false }
+tendermint-rpc   = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", features = ["http-client", "websocket-client"] }
+tendermint-proto = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8" }
+tendermint-light-client = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", default-features = false, features = ["rpc-client", "secp256k1", "unstable"] }
+tendermint-light-client-verifier = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", default-features = false }
+ics07-tendermint = { path = "../../../light-clients/ics07-tendermint" }

--- a/algorithms/tendermint/primitives/Cargo.toml
+++ b/algorithms/tendermint/primitives/Cargo.toml
@@ -13,12 +13,12 @@ derive_more = { version = "0.99.17", default-features = false, features = ["disp
 # ibc
 ibc = { path = "../../../ibc/modules", features = [] }
 ibc-proto = { path = "../../../ibc/proto" }
-pallet-ibc = { path = "../../../../parachain/frame/ibc" }
+pallet-ibc = { path = "../../../contracts/pallet-ibc" }
 
 # Tendermint
-tendermint = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", default-features = false }
-tendermint-rpc   = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", features = ["http-client", "websocket-client"] }
-tendermint-proto = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8" }
-tendermint-light-client = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", default-features = false, features = ["rpc-client", "secp256k1", "unstable"] }
-tendermint-light-client-verifier = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", default-features = false }
+tendermint = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426", default-features = false }
+tendermint-rpc   = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426", features = ["http-client", "websocket-client"] }
+tendermint-proto = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426" }
+tendermint-light-client = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426", default-features = false, features = ["rpc-client", "secp256k1", "unstable"] }
+tendermint-light-client-verifier = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426", default-features = false }
 ics07-tendermint = { path = "../../../light-clients/ics07-tendermint" }

--- a/algorithms/tendermint/primitives/src/error.rs
+++ b/algorithms/tendermint/primitives/src/error.rs
@@ -1,0 +1,28 @@
+// Copyright (C) 2022 ComposableFi.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use derive_more::{Display, From};
+use thiserror::Error;
+
+#[derive(From, Debug, Display)]
+pub enum Error {
+	Custom(String),
+}
+
+impl From<String> for Error {
+	fn from(error: String) -> Self {
+		Self::Custom(error)
+	}
+}

--- a/algorithms/tendermint/primitives/src/error.rs
+++ b/algorithms/tendermint/primitives/src/error.rs
@@ -13,10 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use derive_more::{Display, From};
-use thiserror::Error;
+use derive_more::Display;
 
-#[derive(From, Debug, Display)]
+#[derive(Debug, Display)]
 pub enum Error {
 	Custom(String),
 }

--- a/algorithms/tendermint/primitives/src/lib.rs
+++ b/algorithms/tendermint/primitives/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod error;
+
+use error::Error;

--- a/algorithms/tendermint/prover/Cargo.toml
+++ b/algorithms/tendermint/prover/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "tendermint-prover"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+# ibc
+ibc = { path = "../../../ibc/modules", features = [] }
+ibc-proto = { path = "../../../ibc/proto" }
+
+# Tendermint
+tendermint = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", default-features = false }
+tendermint-rpc   = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", features = ["http-client", "websocket-client"] }
+tendermint-proto = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8" }
+tendermint-light-client = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", default-features = false, features = ["rpc-client", "secp256k1", "unstable"] }
+tendermint-light-client-verifier = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", default-features = false }

--- a/algorithms/tendermint/prover/Cargo.toml
+++ b/algorithms/tendermint/prover/Cargo.toml
@@ -11,8 +11,8 @@ ibc = { path = "../../../ibc/modules", features = [] }
 ibc-proto = { path = "../../../ibc/proto" }
 
 # Tendermint
-tendermint = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", default-features = false }
-tendermint-rpc   = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", features = ["http-client", "websocket-client"] }
-tendermint-proto = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8" }
-tendermint-light-client = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", default-features = false, features = ["rpc-client", "secp256k1", "unstable"] }
-tendermint-light-client-verifier = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", default-features = false }
+tendermint = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426", default-features = false }
+tendermint-rpc   = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426", features = ["http-client", "websocket-client"] }
+tendermint-proto = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426" }
+tendermint-light-client = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426", default-features = false, features = ["rpc-client", "secp256k1", "unstable"] }
+tendermint-light-client-verifier = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426", default-features = false }

--- a/algorithms/tendermint/verifier/Cargo.toml
+++ b/algorithms/tendermint/verifier/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "tendermint-verifier"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+# ibc
+ibc = { path = "../../../ibc/modules", features = [] }
+ibc-proto = { path = "../../../ibc/proto" }
+pallet-ibc = { path = "../../../../parachain/frame/ibc" }
+
+# Tendermint
+tendermint = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", default-features = false }
+tendermint-rpc   = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", features = ["http-client", "websocket-client"] }
+tendermint-proto = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8" }
+tendermint-light-client = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", default-features = false, features = ["rpc-client", "secp256k1", "unstable"] }
+tendermint-light-client-verifier = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", default-features = false }
+ics07-tendermint = { path = "../../../light-clients/ics07-tendermint" }
+tendermint-primitives = { package = "tendermint-primitives", path = "../primitives", default-features = false }

--- a/algorithms/tendermint/verifier/Cargo.toml
+++ b/algorithms/tendermint/verifier/Cargo.toml
@@ -6,16 +6,18 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+# crates.io
+futures-util = "0.3.25"
+
 # ibc
 ibc = { path = "../../../ibc/modules", features = [] }
 ibc-proto = { path = "../../../ibc/proto" }
-pallet-ibc = { path = "../../../../parachain/frame/ibc" }
-
+pallet-ibc = { path = "../../../contracts/pallet-ibc" }
 # Tendermint
-tendermint = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", default-features = false }
-tendermint-rpc   = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", features = ["http-client", "websocket-client"] }
-tendermint-proto = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8" }
-tendermint-light-client = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", default-features = false, features = ["rpc-client", "secp256k1", "unstable"] }
-tendermint-light-client-verifier = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", default-features = false }
+tendermint = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426", default-features = false }
+tendermint-rpc   = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426", features = ["http-client", "websocket-client"] }
+tendermint-proto = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426" }
+tendermint-light-client = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426", default-features = false, features = ["rpc-client", "secp256k1", "unstable"] }
+tendermint-light-client-verifier = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426", default-features = false }
 ics07-tendermint = { path = "../../../light-clients/ics07-tendermint" }
 tendermint-primitives = { package = "tendermint-primitives", path = "../primitives", default-features = false }

--- a/algorithms/tendermint/verifier/src/lib.rs
+++ b/algorithms/tendermint/verifier/src/lib.rs
@@ -1,0 +1,110 @@
+//! This section mainly has been ported from `InformalSystems/hermes/relayer/src/light_client`
+use futures_util::future::TryFutureExt;
+use ibc::Height as ICSHeight;
+use ics07_tendermint::client_state::ClientState as TmClientState;
+use pallet_ibc::light_clients::HostFunctionsManager;
+use tendermint_light_client::{
+	components::{self, io::AsyncIo, io::AtHeight, io::RpcIo},
+	light_client::LightClient as TmLightClient,
+	state::State as LightClientState,
+	store::{memory::MemoryStore, LightStore},
+};
+use tendermint_light_client_verifier::{
+	host_functions::CryptoProvider,
+	operations::{ProdCommitValidator, ProdVotingPowerCalculator},
+	options::Options as TmOptions,
+	predicates::ProdPredicates,
+	types::{Height as TMHeight, LightBlock, PeerId, Status},
+	PredicateVerifier, ProdVerifier,
+};
+use tendermint_primitives::error::Error;
+use tendermint_rpc::{Client, HttpClient, Url};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Verified<H> {
+	/// Verified target
+	pub target: H,
+	/// Supporting headers needed to verify `target`
+	pub supporting: Vec<H>,
+}
+
+#[derive(Clone, Debug)]
+pub struct LightClient {
+	peer_id: PeerId,
+	io: RpcIo,
+}
+
+impl LightClient {
+	pub async fn init_light_client(rpc_url: Url) -> Result<Self, Error> {
+		let rpc_client = HttpClient::new(rpc_url).map_err(|e| Error::from(e.to_string()))?;
+		let peer_id: PeerId = rpc_client
+			.status()
+			.await
+			.map(|s| s.node_info.id)
+			.map_err(|e| Error::from(e.to_string()))?;
+		let io = RpcIo::new(peer_id, rpc_client, None);
+		Ok(Self { peer_id, io })
+	}
+
+	pub async fn prepare_tendermint_light_client<HostFunctions>(
+		&self,
+		client_state: &TmClientState<HostFunctions>,
+	) -> Result<TmLightClient<HostFunctions>, Error>
+	where
+		HostFunctions: CryptoProvider,
+	{
+		let clock = components::clock::SystemClock;
+		let verifier: PredicateVerifier<
+			ProdPredicates<HostFunctions>,
+			ProdVotingPowerCalculator<HostFunctions>,
+			ProdCommitValidator<HostFunctions>,
+			HostFunctions,
+		> = ProdVerifier::default();
+		let scheduler = components::scheduler::basic_bisecting_schedule;
+		let params = TmOptions {
+			trust_threshold: client_state.trust_level.try_into().unwrap(),
+			trusting_period: client_state.trusting_period,
+			clock_drift: client_state.max_clock_drift,
+		};
+
+		Ok(TmLightClient::new(self.peer_id, params, clock, scheduler, verifier, self.io.clone()))
+	}
+
+	pub async fn prepare_state(&self, trusted: ICSHeight) -> Result<LightClientState, Error> {
+		let trusted_height =
+			TMHeight::try_from(trusted.revision_height).map_err(|e| Error::from(e.to_string()))?;
+
+		let trusted_block = self.fetch_light_block(AtHeight::At(trusted_height)).await?;
+		let mut store = MemoryStore::new();
+		store.insert(trusted_block, Status::Trusted);
+
+		Ok(LightClientState::new(store))
+	}
+
+	async fn fetch_light_block(&self, height: AtHeight) -> Result<LightBlock, Error> {
+		self.io.fetch_light_block(height).map_err(|e| Error::from(e.to_string())).await
+	}
+
+	/// Perform forward verification with bisection.
+	pub async fn verify<HostFuntions>(
+		&self,
+		trusted: ICSHeight,
+		target: ICSHeight,
+		client_state: &TmClientState<HostFunctionsManager>,
+	) -> Result<LightBlock, Error> {
+		let target_height =
+			TMHeight::try_from(target.revision_height).map_err(|e| Error::from(e.to_string()))?;
+
+		let client = self
+			.prepare_tendermint_light_client::<HostFunctionsManager>(client_state)
+			.await?;
+		let mut state = self.prepare_state(trusted).await?;
+
+		// Verify the target header
+		let target = client
+			.verify_to_target(target_height, &mut state)
+			.map_err(|e| Error::from(e.to_string()))
+			.await?;
+		Ok(target)
+	}
+}

--- a/contracts/pallet-ibc/Cargo.toml
+++ b/contracts/pallet-ibc/Cargo.toml
@@ -30,8 +30,8 @@ sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-
 cumulus-primitives-core  = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.27" }
 # ibc
 ibc-proto = { path = "../../ibc/proto", default-features = false }
-tendermint = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", optional = true, default-features = false }
-tendermint-proto = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", default-features = false }
+tendermint = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426", optional = true, default-features = false }
+tendermint-proto = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426", default-features = false }
 ics23 = { git = "https://github.com/composablefi/ics23", rev = "b500a5c6068eb53c83c4c6c13bd9d8c25e0bf927", default-features = false }
 grandpa-client-primitives = { package = "grandpa-light-client-primitives", path = "../../algorithms/grandpa/primitives", default-features = false }
 beefy-client-primitives = { package = "beefy-light-client-primitives", path = "../../algorithms/beefy/primitives", default-features = false }
@@ -67,8 +67,8 @@ features = ["derive"]
 default-features = false
 
 [dependencies.tendermint-light-client-verifier]
-git = "https://github.com/composableFi/tendermint-rs"
-rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8"
+git = "https://github.com/farhad-shabani/tendermint-rs"
+rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426"
 default-features = false
 
 [dev-dependencies]
@@ -82,7 +82,7 @@ prost = { version = "0.10" }
 serde = { version = "1.0" }
 simple-iavl = { git = "https://github.com/ComposableFi/simple-avl", rev = "452a1126bfb8a861354b413755ac3c8fda3da4ec" }
 sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-tendermint = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8" }
+tendermint = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426" }
 balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
 pallet-assets = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
 pallet-ibc-ping = { path = "ping", default-features = false }

--- a/contracts/pallet-ibc/rpc/Cargo.toml
+++ b/contracts/pallet-ibc/rpc/Cargo.toml
@@ -27,7 +27,7 @@ sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "pol
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
 sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-tendermint-proto = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8" }
+tendermint-proto = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426" }
 
 [dependencies.ibc]
 path = "../../../ibc/modules"

--- a/contracts/pallet-ibc/src/light_clients.rs
+++ b/contracts/pallet-ibc/src/light_clients.rs
@@ -49,7 +49,7 @@ impl ics23::HostFunctionsProvider for HostFunctionsManager {
 	}
 }
 
-impl tendermint_light_client_verifier::host_functions::HostFunctionsProvider
+impl tendermint_light_client_verifier::host_functions::CryptoProvider
 	for HostFunctionsManager
 {
 	fn sha2_256(message: &[u8]) -> [u8; 32] {

--- a/hyperspace/config_cosmos.toml
+++ b/hyperspace/config_cosmos.toml
@@ -1,0 +1,28 @@
+[chain_a]
+type = "cosmos"
+name = "chain-a"
+chain_id = "ibc-0"
+rpc_url = "http://127.0.0.1:27010"
+grpc_url = "http://127.0.0.1:9090"
+websocket_url = "ws://127.0.0.1:27010/websocket"
+client_id = "7-tendermint-0"
+connection_id = "connection-0"
+account_prefix = "cosmos"
+store_prefix = 'ibc'
+key_name = "alice"
+
+[chain_b]
+type = "cosmos"
+name = "chain-b"
+chain_id = "ibc-1"
+rpc_url = "http://127.0.0.1:27020"
+grpc_url = "http://127.0.0.1:9091"
+websocket_url = "ws://127.0.0.1:27020/websocket"
+client_id = "7-tendermint-0"
+connection_id = "connection-0"
+account_prefix = "cosmos"
+store_prefix = 'ibc'
+key_name = "bob"
+
+[core]
+prometheus_endpoint = "https://127.0.0.1"

--- a/hyperspace/core/Cargo.toml
+++ b/hyperspace/core/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Seun Lanlege <seunlanlege@gmail.com>", "David Salami <david.salami@g
 
 [dependencies]
 primitives = { path = "../primitives", package = "hyperspace-primitives" }
-parachain = { path = "../parachain", package = "hyperspace-parachain" }
+parachain = { path = "../parachain", package = "hyperspace-parachain", optional = true }
 cosmos = { path = "../cosmos", package = "hyperspace-cosmos", optional = true }
 #near = { path = "near", package = "hyperspace-near", optional = true }
 metrics = { path = "../metrics", package = "hyperspace-metrics" }
@@ -31,14 +31,15 @@ prometheus = { version = "0.13.0", default-features = false }
 # ibc
 ibc = { path = "../../ibc/modules", features = [] }
 ibc-proto = { path = "../../ibc/proto" }
-tendermint-proto = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8" }
 ibc-rpc = { path = "../../contracts/pallet-ibc/rpc" }
+tendermint-proto = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8" }
 
-ics11-beefy = { path = "../../light-clients/ics11-beefy" }
-#ics13-near = { path = "../../light-clients/ics13-near" }
 light-client-common = { path = "../../light-clients/common" }
 pallet-ibc = { path = "../../contracts/pallet-ibc" }
-ics10-grandpa = { path = "../../light-clients/ics10-grandpa" }
+ics07-tendermint = { path = "../../light-clients/ics07-tendermint", optional = true }
+ics10-grandpa = { path = "../../light-clients/ics10-grandpa", optional = true }
+ics11-beefy = { path = "../../light-clients/ics11-beefy", optional = true }
+# ics13-near = { path = "../light-clients/ics13-near" }
 
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
 sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
@@ -49,6 +50,7 @@ subxt = { git = "https://github.com/paritytech/subxt", rev = "1736f618d940a69ab2
 derive_more = "0.99.17"
 prost = "0.10"
 parachain = { path = "../parachain", package = "hyperspace-parachain", features = ["testing"] }
+cosmos = { path = "../cosmos", package = "hyperspace-cosmos", features = ["testing"] }
 
 # substrate
 subxt = { git = "https://github.com/paritytech/subxt", rev = "1736f618d940a69ab212a686984c3be25b08d1c2" }
@@ -65,6 +67,7 @@ sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkad
 build-metadata-from-ws = [
     "parachain/build-metadata-from-ws",
 ]
+parachain = ["dep:parachain", "ics10-grandpa", "ics11-beefy"]
+cosmos = ["dep:cosmos", "ics07-tendermint"]
 #near = ["dep:near"]
-#cosmos = ["dep:cosmos"]
 testing = [ "primitives/testing", "parachain/testing" ]

--- a/hyperspace/core/Cargo.toml
+++ b/hyperspace/core/Cargo.toml
@@ -32,7 +32,7 @@ prometheus = { version = "0.13.0", default-features = false }
 ibc = { path = "../../ibc/modules", features = [] }
 ibc-proto = { path = "../../ibc/proto" }
 ibc-rpc = { path = "../../contracts/pallet-ibc/rpc" }
-tendermint-proto = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8" }
+tendermint-proto = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426" }
 
 light-client-common = { path = "../../light-clients/common" }
 pallet-ibc = { path = "../../contracts/pallet-ibc" }

--- a/hyperspace/core/src/chain.rs
+++ b/hyperspace/core/src/chain.rs
@@ -121,6 +121,7 @@ impl From<String> for AnyError {
 #[async_trait]
 impl IbcProvider for AnyChain {
 	type FinalityEvent = AnyFinalityEvent;
+	type Hash = H256;
 	type Error = AnyError;
 
 	async fn query_latest_ibc_events<T>(
@@ -510,8 +511,8 @@ impl IbcProvider for AnyChain {
 
 	async fn query_client_id_from_tx_hash(
 		&self,
-		tx_hash: H256,
-		block_hash: Option<H256>,
+		tx_hash: Self::Hash,
+		block_hash: Option<Self::Hash>,
 	) -> Result<ClientId, Self::Error> {
 		match self {
 			Self::Parachain(chain) => chain

--- a/hyperspace/cosmos/Cargo.toml
+++ b/hyperspace/cosmos/Cargo.toml
@@ -38,5 +38,9 @@ ics07-tendermint = { path = "../../light-clients/ics07-tendermint" }
 # tendermint-verifier = { path = "../../algorithms/tendermint/verifier" }
 # tendermint-primitives = {  path = "../../algorithms/tendermint/primitives" }
 
+# Substrate
+subxt = { git = "https://github.com/paritytech/subxt", rev = "51179a8b72472d0b43c91cda75a1ddc3fddb9555" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", features = ["full_crypto"] }
+
 [features]
 testing = ["primitives/testing"]

--- a/hyperspace/cosmos/Cargo.toml
+++ b/hyperspace/cosmos/Cargo.toml
@@ -2,7 +2,41 @@
 name = "hyperspace-cosmos"
 version = "0.1.0"
 edition = "2021"
-authors = ["Composable Developers"]
+authors = ["Farhad Shabani <farhad.shabani@gmail.com>"]
 
 [dependencies]
-#primitives = { path = "../primitives", package = "hyperspace-primitives" }
+anyhow = "1.0.65"
+async-trait = "0.1.53"
+codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
+log = "0.4.17"
+env_logger = "0.9.0"
+futures = "0.3.21"
+primitives = { path = "../primitives", package = "hyperspace-primitives" }
+jsonrpsee = "0.15.1"
+jsonrpsee-ws-client = "0.14.0"
+serde = {version="1.0.137", features = ["derive"]}
+ss58-registry = "1.28.0"
+thiserror = "1.0.31"
+tonic = { version = "0.7.2", features = ["tls", "tls-roots"] }
+
+# ibc
+ibc = { path = "../../ibc/modules", features = [] }
+ibc-proto = { path = "../../ibc/proto" }
+ibc-rpc = { path = "../../contracts/pallet-ibc/rpc" }
+pallet-ibc = { path = "../../contracts/pallet-ibc" }
+# light-client-common = { path = "../../light-clients/common" }
+
+
+# Tendermint
+tendermint = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", default-features = false }
+tendermint-rpc   = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", features = ["http-client", "websocket-client"] }
+tendermint-proto = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8" }
+ics07-tendermint = { path = "../../light-clients/ics07-tendermint" }
+# tendermint-light-client = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", default-features = false, features = ["rpc-client", "secp256k1", "unstable"] }
+# tendermint-light-client-verifier = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", default-features = false }
+# tendermint-prover = { path = "../../algorithms/tendermint/prover" }
+# tendermint-verifier = { path = "../../algorithms/tendermint/verifier" }
+# tendermint-primitives = {  path = "../../algorithms/tendermint/primitives" }
+
+[features]
+testing = ["primitives/testing"]

--- a/hyperspace/cosmos/Cargo.toml
+++ b/hyperspace/cosmos/Cargo.toml
@@ -32,15 +32,15 @@ pallet-ibc = { path = "../../contracts/pallet-ibc" }
 
 
 # Tendermint
-tendermint = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", default-features = false }
-tendermint-rpc   = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", features = ["http-client", "websocket-client"] }
-tendermint-proto = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8" }
+tendermint = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426", default-features = false }
+tendermint-rpc   = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426", features = ["http-client", "websocket-client"] }
+tendermint-proto = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426" }
 ics07-tendermint = { path = "../../light-clients/ics07-tendermint" }
-# tendermint-light-client = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", default-features = false, features = ["rpc-client", "secp256k1", "unstable"] }
-# tendermint-light-client-verifier = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", default-features = false }
-# tendermint-prover = { path = "../../algorithms/tendermint/prover" }
-# tendermint-verifier = { path = "../../algorithms/tendermint/verifier" }
-# tendermint-primitives = {  path = "../../algorithms/tendermint/primitives" }
+tendermint-light-client = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426", default-features = false, features = ["rpc-client", "secp256k1", "unstable"] }
+tendermint-light-client-verifier = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426", default-features = false }
+tendermint-prover = { path = "../../algorithms/tendermint/prover" }
+tendermint-verifier = { path = "../../algorithms/tendermint/verifier" }
+tendermint-primitives = {  path = "../../algorithms/tendermint/primitives" }
 
 # Substrate
 subxt = { git = "https://github.com/paritytech/subxt", rev = "51179a8b72472d0b43c91cda75a1ddc3fddb9555" }

--- a/hyperspace/cosmos/Cargo.toml
+++ b/hyperspace/cosmos/Cargo.toml
@@ -7,7 +7,10 @@ authors = ["Farhad Shabani <farhad.shabani@gmail.com>"]
 [dependencies]
 anyhow = "1.0.65"
 async-trait = "0.1.53"
+bech32 = "0.9.1"
+bitcoin = { version = "0.29.1", features = ["serde"] }
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
+dirs-next = "2.0.0"
 log = "0.4.17"
 env_logger = "0.9.0"
 futures = "0.3.21"
@@ -15,6 +18,7 @@ primitives = { path = "../primitives", package = "hyperspace-primitives" }
 jsonrpsee = "0.15.1"
 jsonrpsee-ws-client = "0.14.0"
 serde = {version="1.0.137", features = ["derive"]}
+serde_json = { version = "1" }
 ss58-registry = "1.28.0"
 thiserror = "1.0.31"
 tonic = { version = "0.7.2", features = ["tls", "tls-roots"] }

--- a/hyperspace/cosmos/Cargo.toml
+++ b/hyperspace/cosmos/Cargo.toml
@@ -13,8 +13,10 @@ codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive
 dirs-next = "2.0.0"
 log = "0.4.17"
 env_logger = "0.9.0"
+k256 = { version = "0.10.4", features = ["ecdsa-core", "ecdsa", "sha256"]}
 futures = "0.3.21"
 primitives = { path = "../primitives", package = "hyperspace-primitives" }
+prost = { version = "0.10" }
 jsonrpsee = "0.15.1"
 jsonrpsee-ws-client = "0.14.0"
 serde = {version="1.0.137", features = ["derive"]}

--- a/hyperspace/cosmos/src/chain.rs
+++ b/hyperspace/cosmos/src/chain.rs
@@ -55,10 +55,10 @@ where
 
 		// Create and Encode TxBody
 		let body = TxBody {
-			messages: messages.to_vec(),
-			memo: "".to_string(), //TODO: Check if this is correct
+			messages: messages.to_vec(), 						
+			memo: "".to_string(), 								//TODO: Check if this is correct
 			timeout_height: 0_u64,
-			extension_options: Vec::<Any>::new(), //TODO: Check if this is correct
+			extension_options: Vec::<Any>::new(), 				//TODO: Check if this is correct
 			non_critical_extension_options: Vec::<Any>::new(),
 		};
 		let mut body_bytes = Vec::new();

--- a/hyperspace/cosmos/src/chain.rs
+++ b/hyperspace/cosmos/src/chain.rs
@@ -1,0 +1,40 @@
+use futures::Stream;
+use ibc_proto::google::protobuf::Any;
+use primitives::{Chain, IbcProvider};
+use std::pin::Pin;
+
+use crate::finality_protocol::FinalityProtocol;
+
+use super::{error::Error, CosmosClient};
+
+#[async_trait::async_trait]
+impl<H> Chain for CosmosClient<H>
+where
+	H: Clone + Send + Sync + 'static,
+{
+	fn name(&self) -> &str {
+		&*self.name
+	}
+
+	fn block_max_weight(&self) -> u64 {
+		todo!()
+	}
+
+	async fn estimate_weight(&self, messages: Vec<Any>) -> Result<u64, Self::Error> {
+		todo!()
+	}
+
+	async fn finality_notifications(
+		&self,
+	) -> Pin<Box<dyn Stream<Item = <Self as IbcProvider>::FinalityEvent> + Send + Sync>> {
+		match self.finality_protocol {
+			FinalityProtocol::Tendermint => {
+				todo!()
+			},
+		}
+	}
+
+	async fn submit(&self, messages: Vec<Any>) -> Result<(sp_core::H256, Option<sp_core::H256>), Error> {
+		todo!();
+	}
+}

--- a/hyperspace/cosmos/src/chain.rs
+++ b/hyperspace/cosmos/src/chain.rs
@@ -1,11 +1,16 @@
-use futures::Stream;
-use ibc_proto::google::protobuf::Any;
-use primitives::{Chain, IbcProvider};
-use std::pin::Pin;
-
-use crate::finality_protocol::FinalityProtocol;
-
 use super::{error::Error, CosmosClient};
+use crate::finality_protocol::FinalityProtocol;
+use futures::Stream;
+use ibc_proto::cosmos::tx::v1beta1::{
+	mode_info::{Single, Sum},
+	AuthInfo, ModeInfo, SignDoc, SignerInfo, TxBody, TxRaw,
+};
+use ibc_proto::google::protobuf::Any;
+use k256::ecdsa::{signature::Signer as _, Signature, SigningKey};
+use primitives::{Chain, IbcProvider};
+use prost::Message;
+use std::pin::Pin;
+use tendermint_rpc::Client;
 
 #[async_trait::async_trait]
 impl<H> Chain for CosmosClient<H>
@@ -34,7 +39,66 @@ where
 		}
 	}
 
-	async fn submit(&self, messages: Vec<Any>) -> Result<(sp_core::H256, Option<sp_core::H256>), Error> {
-		todo!();
+	async fn submit(&self, messages: Vec<Any>) -> Result<(Self::Hash, Option<Self::Hash>), Error> {
+		// Create SignerInfo by encoding the keybase
+		let mut pk_buf = Vec::new();
+		Message::encode(&self.keybase.public_key.to_pub().to_bytes(), &mut pk_buf)
+			.map_err(|e| Error::from(e.to_string()))?;
+
+		let pk_type = "/cosmos.crypto.secp256k1.PubKey".to_string();
+		let pk_any = Any { type_url: pk_type, value: pk_buf };
+		let single = Single { mode: 1 };
+		let sum_single = Some(Sum::Single(single));
+		let mode = Some(ModeInfo { sum: sum_single });
+		let signer_info =
+			SignerInfo { public_key: Some(pk_any), mode_info: mode, sequence: 0 as u64 };
+
+		// Create and Encode TxBody
+		let body = TxBody {
+			messages: messages.to_vec(),
+			memo: "".to_string(), //TODO: Check if this is correct
+			timeout_height: 0_u64,
+			extension_options: Vec::<Any>::new(), //TODO: Check if this is correct
+			non_critical_extension_options: Vec::<Any>::new(),
+		};
+		let mut body_bytes = Vec::new();
+		Message::encode(&body, &mut body_bytes).map_err(|e| Error::from(e.to_string()))?;
+
+		// Create and Encode AuthInfo
+		let auth_info = AuthInfo { signer_infos: vec![signer_info], fee: None };
+		let mut auth_info_bytes = Vec::new();
+		Message::encode(&auth_info, &mut auth_info_bytes)
+			.map_err(|e| Error::from(e.to_string()))?;
+
+		// Create and Encode SignDoc
+		let sign_doc = SignDoc {
+			body_bytes: body_bytes.clone(),
+			auth_info_bytes: auth_info_bytes.clone(),
+			chain_id: self.chain_id.to_string(),
+			account_number: self.query_account().await?.account_number,
+		};
+		let mut signdoc_buf = Vec::new();
+		Message::encode(&sign_doc, &mut signdoc_buf).unwrap();
+
+		// Create signature
+		let private_key_bytes = self.keybase.private_key.to_priv().to_bytes();
+		let signing_key = SigningKey::from_bytes(private_key_bytes.as_slice())
+			.map_err(|e| Error::from(e.to_string()))?;
+		let signature: Signature = signing_key.sign(&signdoc_buf);
+		let signature_bytes = signature.as_ref().to_vec();
+
+		// Create and Encode TxRaw
+		let tx_raw = TxRaw { body_bytes, auth_info_bytes, signatures: vec![signature_bytes] };
+		let mut tx_bytes = Vec::new();
+		Message::encode(&tx_raw, &mut tx_bytes).map_err(|e| Error::from(e.to_string()))?;
+
+		// Submit transaction
+		let response = self
+			.rpc_client
+			.broadcast_tx_sync(tx_bytes.into())
+			.await
+			.map_err(|e| Error::from(format!("failed to broadcast transaction {:?}", e)))?;
+
+		Ok((response.hash, None))
 	}
 }

--- a/hyperspace/cosmos/src/error.rs
+++ b/hyperspace/cosmos/src/error.rs
@@ -1,0 +1,51 @@
+use ibc::{core::ics02_client, timestamp::ParseTimestampError};
+use std::num::ParseIntError;
+use thiserror::Error;
+
+/// Error definitions for the cosmos client in accordance with the parachain's Error type.
+#[derive(Error, Debug)]
+pub enum Error {
+	/// An error from the rpc interface
+	#[error("Rpc client error: {0}")]
+	RpcError(String),
+	/// Update module name in call definition
+	#[error("Module '{0}' not found in metadata, update static definition of call")]
+	ModuleNotFound(&'static str),
+	/// Call not found, update function name in call definition
+	#[error("Call '{0}' not found in metadata, update static definition of call")]
+	CallNotFound(&'static str),
+	/// Custom error
+	#[error("{0}")]
+	Custom(String),
+	#[error("Ibc channel error")]
+	IbcChannel(#[from] ibc::core::ics04_channel::error::Error),
+	/// Error querying packets
+	#[error("Could not retrieve packets from {channel_id}/{port_id} for sequences {:?}", .sequences)]
+	QueryPackets { channel_id: String, port_id: String, sequences: Vec<u64>, err: String },
+	/// Failed to rehydrate client state
+	#[error("Error decoding some value: {0}")]
+	ClientStateRehydration(String),
+	/// Failed to get client update header from finality notification
+	#[error("Error constructing a client update header: {0}")]
+	HeaderConstruction(String),
+	/// Errors associated with ics-02 client
+	#[error("Ibc client error: {0}")]
+	IbcClient(#[from] ics02_client::error::Error),
+	/// Ics-20 errors
+	#[error("Ics-20 error: {0}")]
+	Ics20Error(#[from] ibc::applications::transfer::error::Error),
+	/// parse error
+	#[error("Failed to parse block numbers: {0}")]
+	ParseIntError(#[from] ParseIntError),
+	/// Error occured parsing timestamp
+	#[error("Timestamp error: {0}")]
+	ParseTimestamp(#[from] ParseTimestampError),
+	#[error("Jsonrpsee error: {0}")]
+	JosnrpseeError(#[from] jsonrpsee::core::Error),
+}
+
+impl From<String> for Error {
+	fn from(error: String) -> Self {
+		Self::Custom(error)
+	}
+}

--- a/hyperspace/cosmos/src/finality_protocol.rs
+++ b/hyperspace/cosmos/src/finality_protocol.rs
@@ -1,0 +1,53 @@
+//! Light client protocols for cosmos chains.
+
+use crate::CosmosClient;
+use codec::{Decode, Encode};
+use ibc::events::IbcEvent;
+use ibc_proto::google::protobuf::Any;
+use ics07_tendermint::client_message::Header;
+
+use primitives::{Chain, KeyProvider, UpdateType};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum FinalityProtocol {
+	Tendermint,
+}
+
+/// Finality event for cosmos chains.
+pub enum FinalityEvent {
+	Tendermint(Header),
+}
+
+impl FinalityProtocol {
+	pub async fn query_latest_ibc_events<C, H>(
+		&self,
+		source: &mut CosmosClient<H>,
+		finality_event: FinalityEvent,
+		counterparty: &C,
+	) -> Result<(Any, Vec<IbcEvent>, UpdateType), anyhow::Error>
+	where
+		H: Clone + Send + Sync + 'static,
+		C: Chain,
+		CosmosClient<H>: Chain + KeyProvider,
+	{
+		match self {
+			FinalityProtocol::Tendermint =>
+				query_latest_ibc_events_with_tendermint(source, finality_event, counterparty).await,
+		}
+	}
+}
+
+/// Query the latest events that have been finalized by the Tendermint finality protocol.
+pub async fn query_latest_ibc_events_with_tendermint<C, H>(
+	source: &mut CosmosClient<H>,
+	finality_event: FinalityEvent,
+	counterparty: &C,
+) -> Result<(Any, Vec<IbcEvent>, UpdateType), anyhow::Error>
+where
+	C: Chain,
+	H: Clone + Send + Sync + 'static,
+	CosmosClient<H>: Chain + KeyProvider,
+{
+	todo!()
+}

--- a/hyperspace/cosmos/src/key_provider.rs
+++ b/hyperspace/cosmos/src/key_provider.rs
@@ -1,0 +1,12 @@
+use super::CosmosClient;
+use crate::error::Error;
+use primitives::KeyProvider;
+use std::str::FromStr;
+
+impl<H> KeyProvider for CosmosClient<H> {
+	fn account_id(&self) -> ibc::signer::Signer {
+		ibc::signer::Signer::from_str(&self.key_name.as_str())
+			.map_err(|_| Error::Custom("Invalid key name".to_string()))
+			.unwrap()
+	}
+}

--- a/hyperspace/cosmos/src/key_provider.rs
+++ b/hyperspace/cosmos/src/key_provider.rs
@@ -1,12 +1,74 @@
 use super::CosmosClient;
 use crate::error::Error;
+use bech32::{ToBase32, Variant};
+use bitcoin::{
+	hashes::hex::ToHex,
+	util::bip32::{ExtendedPrivKey, ExtendedPubKey},
+};
+use ibc::core::ics24_host::identifier::ChainId;
 use primitives::KeyProvider;
-use std::str::FromStr;
+use serde::{Deserialize, Serialize};
+use std::{path::Path, str::FromStr};
+use tendermint::account::Id as AccountId;
+
+pub const KEYSTORE_DEFAULT_FOLDER: &str = ".hermes/keys/";
+pub const KEYSTORE_DISK_BACKEND: &str = "keyring-test";
+pub const KEYSTORE_FILE_EXTENSION: &str = "json";
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KeyEntry {
+	/// Public key
+	pub public_key: ExtendedPubKey,
+
+	/// Private key
+	pub private_key: ExtendedPrivKey,
+
+	/// Account Bech32 format - TODO allow hrp
+	pub account: String,
+
+	/// Address
+	pub address: Vec<u8>,
+}
+
+impl KeyEntry {
+	pub fn new(key_name: &str, chain_id: &ChainId) -> Result<KeyEntry, Error> {
+		let home = dirs_next::home_dir().unwrap();
+		let keys_folder = Path::new(home.as_path())
+			.join(KEYSTORE_DEFAULT_FOLDER)
+			.join(chain_id.as_str())
+			.join(KEYSTORE_DISK_BACKEND);
+		let mut key_file = keys_folder.join(key_name);
+		key_file.set_extension(KEYSTORE_FILE_EXTENSION);
+
+		if !key_file.as_path().exists() {
+			return Err(Error::from(format!("Key file {} does not exist", key_file.display())));
+		}
+
+		let file = std::fs::File::open(&key_file)
+			.map_err(|e| Error::from(format!("Could not open key file {}", e)))?;
+
+		let key_entry = serde_json::from_reader(file)
+			.map_err(|e| Error::from(format!("Could not deserialize key file {}", e)))?;
+
+		Ok(key_entry)
+	}
+}
 
 impl<H> KeyProvider for CosmosClient<H> {
 	fn account_id(&self) -> ibc::signer::Signer {
-		ibc::signer::Signer::from_str(&self.key_name.as_str())
-			.map_err(|_| Error::Custom("Invalid key name".to_string()))
-			.unwrap()
+		let key_entry = self.keybase.clone();
+		let address = key_entry.address.to_hex();
+		let account = AccountId::from_str(address.as_str())
+			.map_err(|e| Error::from(format!("Could not parse account id {}", e)))
+			.unwrap();
+		let bech32 =
+			bech32::encode(self.account_prefix.as_str(), account.to_base32(), Variant::Bech32)
+				.map_err(|e| Error::from(format!("Could not encode account id {}", e)))
+				.unwrap();
+		let signer = bech32
+			.parse()
+			.map_err(|e| Error::from(format!("Could not parse account id {}", e)))
+			.unwrap();
+		signer
 	}
 }

--- a/hyperspace/cosmos/src/lib.rs
+++ b/hyperspace/cosmos/src/lib.rs
@@ -1,1 +1,9 @@
+#![allow(clippy::all)]
 
+pub mod chain;
+pub mod error;
+pub mod finality_protocol;
+pub mod key_provider;
+pub mod provider;
+#[cfg(any(test, feature = "testing"))]
+pub mod test_provider;

--- a/hyperspace/cosmos/src/lib.rs
+++ b/hyperspace/cosmos/src/lib.rs
@@ -7,3 +7,184 @@ pub mod key_provider;
 pub mod provider;
 #[cfg(any(test, feature = "testing"))]
 pub mod test_provider;
+use error::Error;
+use ibc::{
+	core::{
+		ics02_client::{height::Height, trust_threshold::TrustThreshold},
+		ics23_commitment::{commitment::CommitmentPrefix, specs::ProofSpecs},
+		ics24_host::{
+			identifier::{ChainId, ClientId, ConnectionId},
+			path::ClientConsensusStatePath,
+			Path,
+		},
+	},
+	protobuf::Protobuf,
+};
+use ibc_proto::{
+	cosmos::base::query::v1beta1::PageRequest,
+	google::protobuf::Any,
+	ibc::core::{
+		client::v1::{
+			IdentifiedClientState, QueryConsensusStateRequest, QueryConsensusStateResponse,
+		},
+		connection::v1::{IdentifiedConnection, QueryConnectionResponse},
+	},
+};
+use ics07_tendermint::{
+	client_state::ClientState as TmClientState, consensus_state::ConsensusState as TmConsensusState,
+};
+use pallet_ibc::{
+	light_clients::{AnyClientState, AnyConsensusState, HostFunctionsManager},
+	MultiAddress, Timeout, TransferParams,
+};
+use primitives::{IbcProvider, KeyProvider};
+use serde::Deserialize;
+use std::str::FromStr;
+use tendermint::block::Height as TmHeight;
+use tendermint_rpc::{abci::Path as TendermintABCIPath, Client, HttpClient, Url, WebSocketClient};
+// Implements the [`crate::Chain`] trait for cosmos.
+/// This is responsible for:
+/// 1. Tracking a cosmos light client on a counter-party chain, advancing this light
+/// client state  as new finality proofs are observed.
+/// 2. Submiting new IBC messages to this cosmos.
+#[derive(Clone)]
+pub struct CosmosClient<H> {
+	/// Chain name
+	pub name: String,
+	/// Chain rpc client
+	pub rpc_client: HttpClient,
+	/// Chain grpc address
+	pub grpc_url: Url,
+	/// Websocket chain ws client
+	pub ws_client: WebSocketClient,
+	/// Chain Id
+	pub chain_id: String,
+	/// Light client id on counterparty chain
+	pub client_id: Option<ClientId>,
+	/// Connection Id
+	pub connection_id: Option<ConnectionId>,
+	/// Name of the key to use for signing
+	pub key_name: String,
+	/// Account prefix
+	pub account_prefix: String,
+	/// Reference to commitment
+	pub commitment_prefix: CommitmentPrefix,
+	/// Reference to proof specs
+	pub finality_protocol: finality_protocol::FinalityProtocol,
+	pub _phantom: std::marker::PhantomData<H>,
+}
+/// config options for [`ParachainClient`]
+#[derive(Debug, Deserialize)]
+pub struct CosmosClientConfig {
+	/// Chain name
+	pub name: String,
+	/// Cosmos chain Id
+	pub chain_id: String,
+	/// rpc url for cosmos
+	pub rpc_url: Url,
+	/// grpc url for cosmos
+	pub grpc_url: Url,
+	/// websocket url for cosmos
+	pub websocket_url: Url,
+	/// Light client id on counterparty chain
+	pub client_id: Option<String>,
+	/// Connection Id
+	pub connection_id: Option<String>,
+	/// Account prefix
+	pub account_prefix: String,
+	/// Store prefix
+	pub store_prefix: String,
+	/// Name of the key that signs transactions
+	pub key_name: String,
+
+	/*
+	Here is a list of dropped configuration parameters from Hermes Config.toml 
+	that could be set to default values or removed for the MVP phase:
+
+	ub key_store_type: Store,					//TODO: Could be set to any of SyncCryptoStorePtr or KeyStore or KeyEntry types, but not sure yet
+	pub rpc_timeout: Duration,				    //TODO: Could be set to '15s' by default
+	pub default_gas: Option<u64>,	  			//TODO: Could be set to `0` by default
+	pub max_gas: Option<u64>,                   //TODO: DEFAULT_MAX_GAS: u64 = 400_000
+	pub gas_multiplier: Option<GasMultiplier>,  //TODO: Could be set to `1.1` by default
+	pub fee_granter: Option<String>,            //TODO: DEFAULT_FEE_GRANTER: &str = ""
+	pub max_msg_num: MaxMsgNum,                 //TODO: Default is 30, Could be set usize = 1 for test 
+	pub max_tx_size: MaxTxSize,					//TODO: Default is usize = 180000, pub memo_prefix: Memo				  
+												//TODO: Could be set to const MAX_LEN: usize = 50;
+	pub proof_specs: Option<ProofSpecs>,        //TODO: Could be set to None
+	pub sequential_batch_tx: bool,			    //TODO: sequential_send_batched_messages_and_wait_commit() or send_batched_messages_and_wait_commit() ?
+	pub trust_threshold: TrustThreshold,
+	pub gas_price: GasPrice,   				    //TODO: Could be set to `0`
+	pub packet_filter: PacketFilter,            //TODO: AllowAll
+	pub address_type: AddressType,			    //TODO: Type = cosmos
+	pub extension_options: Vec<ExtensionOption>,//TODO: Could be set to None
+	*/
+}
+
+impl<H> CosmosClient<H>
+where
+	Self: KeyProvider,
+	H: Clone + Send + Sync + 'static,
+{
+	/// Initializes a [`CosmosClient`] given a [`CosmosClientConfig`]
+	pub async fn new(config: CosmosClientConfig) -> Result<Self, Error> {
+		let rpc_client = HttpClient::new(config.rpc_url.clone())
+			.map_err(|e| Error::RpcError(format!("{:?}", e)))?;
+		let (ws_client, _ws_driver) = WebSocketClient::new(config.websocket_url.clone())
+			.await
+			.map_err(|e| Error::from(format!("Web Socket Client Error {:?}", e)))?;
+
+		let client_id = Some(
+			ClientId::new(config.client_id.unwrap().as_str(), 0)
+				.map_err(|e| Error::from(format!("Invalid client id {}", e)))?,
+		);
+
+		let commitment_prefix = CommitmentPrefix::try_from(config.store_prefix.as_bytes().to_vec())
+			.map_err(|e| Error::from(format!("Invalid store prefix {}", e)))?;
+
+		Ok(Self {
+			name: config.name,
+			chain_id: config.chain_id,
+			rpc_client,
+			grpc_url: config.grpc_url,
+			ws_client,
+			client_id,
+			connection_id: None,
+			account_prefix: config.account_prefix,
+			commitment_prefix,
+			key_name: config.key_name,
+			finality_protocol: finality_protocol::FinalityProtocol::Tendermint,
+			_phantom: std::marker::PhantomData,
+		})
+	}
+
+	pub fn client_id(&self) -> ClientId {
+		self.client_id.as_ref().unwrap().clone()
+	}
+
+	pub fn set_client_id(&mut self, client_id: ClientId) {
+		self.client_id = Some(client_id)
+	}
+
+	/// Construct a tendermint client state to be submitted to the counterparty chain
+	pub async fn construct_tendermint_client_state(
+		&self,
+	) -> Result<(AnyClientState, AnyConsensusState), Error>
+	where
+		Self: KeyProvider + IbcProvider,
+		H: Clone + Send + Sync + 'static,
+	{
+		todo!()
+	}
+
+	pub async fn submit_create_client_msg(&self, msg: String) -> Result<ClientId, Error> {
+		todo!()
+	}
+
+	pub async fn transfer_tokens(&self, asset_id: u128, amount: u128) -> Result<(), Error> {
+		Ok(())
+	}
+
+	pub async fn submit_sudo_call(&self) -> Result<(), Error> {
+		Ok(())
+	}
+}

--- a/hyperspace/cosmos/src/lib.rs
+++ b/hyperspace/cosmos/src/lib.rs
@@ -5,6 +5,7 @@ pub mod error;
 pub mod finality_protocol;
 pub mod key_provider;
 pub mod provider;
+pub mod utils;
 #[cfg(any(test, feature = "testing"))]
 pub mod test_provider;
 use core::convert::TryFrom;

--- a/hyperspace/cosmos/src/provider.rs
+++ b/hyperspace/cosmos/src/provider.rs
@@ -265,7 +265,31 @@ where
 	}
 
 	async fn query_clients(&self) -> Result<Vec<ClientId>, Self::Error> {
-		todo!()
+		let request = tonic::Request::new(QueryClientStatesRequest { pagination: None }.into());
+		let grpc_client = ibc_proto::ibc::core::client::v1::query_client::QueryClient::connect(
+			self.grpc_url.clone().to_string(),
+		)
+		.await
+		.map_err(|e| Error::RpcError(format!("{:?}", e)))?;
+		let response = grpc_client
+			.clone()
+			.client_states(request)
+			.await
+			.map_err(|e| {
+				Error::from(format!("Failed to query client states from grpc client: {:?}", e))
+			})?
+			.into_inner();
+
+		// Deserialize into domain type
+		let mut clients: Vec<ClientId> = response
+			.client_states
+			.into_iter()
+			.filter_map(|cs| {
+				let id = ClientId::from_str(&cs.client_id).ok()?;
+				Some(id)
+			})
+			.collect();
+		Ok(clients)
 	}
 
 	async fn query_channels(&self) -> Result<Vec<(ChannelId, PortId)>, Self::Error> {

--- a/hyperspace/cosmos/src/provider.rs
+++ b/hyperspace/cosmos/src/provider.rs
@@ -1,0 +1,304 @@
+use super::{error::Error, CosmosClient};
+use crate::finality_protocol::{FinalityEvent, FinalityProtocol};
+use core::{
+	convert::{TryFrom, TryInto},
+	future::Future,
+	str::FromStr,
+	time::Duration,
+};
+use futures::{Stream, TryFutureExt};
+use ibc::{
+	applications::transfer::PrefixedCoin,
+	core::{
+		ics02_client::client_state::ClientType,
+		ics23_commitment::commitment::CommitmentPrefix,
+		ics24_host::identifier::{ChainId, ChannelId, ClientId, ConnectionId, PortId},
+	},
+	events::IbcEvent,
+	timestamp::Timestamp,
+	Height,
+};
+use ibc_proto::{
+	google::protobuf::Any,
+	ibc::core::{
+		channel::v1::{
+			QueryChannelResponse, QueryChannelsRequest, QueryChannelsResponse,
+			QueryNextSequenceReceiveResponse, QueryPacketAcknowledgementResponse,
+			QueryPacketCommitmentResponse, QueryPacketReceiptResponse,
+		},
+		client::v1::{
+			IdentifiedClientState, QueryClientStateResponse, QueryClientStatesRequest,
+			QueryConsensusStateResponse,
+		},
+		connection::v1::{IdentifiedConnection, QueryConnectionResponse},
+	},
+};
+use ibc_rpc::PacketInfo;
+use ics07_tendermint::{
+	client_state::ClientState as TmClientState, consensus_state::ConsensusState as TmConsensusState,
+};
+use pallet_ibc::light_clients::{AnyClientState, AnyConsensusState};
+use primitives::{Chain, IbcProvider, UpdateType};
+use sp_core::H256;
+use std::pin::Pin;
+use tendermint::block::Height as TmHeight;
+use tendermint_rpc::Client;
+use tonic::transport::Channel;
+
+#[async_trait::async_trait]
+impl<H> IbcProvider for CosmosClient<H>
+where
+	H: Clone + Send + Sync + 'static,
+{
+	type FinalityEvent = FinalityEvent;
+	type Error = Error;
+
+	async fn query_latest_ibc_events<C>(
+		&mut self,
+		finality_event: Self::FinalityEvent,
+		counterparty: &C,
+	) -> Result<(Any, Vec<IbcEvent>, UpdateType), anyhow::Error>
+	where
+		C: Chain,
+	{
+		self.finality_protocol
+			.clone()
+			.query_latest_ibc_events(self, finality_event, counterparty)
+			.await
+	}
+
+	async fn ibc_events(&self) -> Pin<Box<dyn Stream<Item = IbcEvent>>> {
+		todo!()
+	}
+
+	async fn query_client_consensus(
+		&self,
+		at: Height,
+		client_id: ClientId,
+		consensus_height: Height,
+	) -> Result<QueryConsensusStateResponse, Self::Error> {
+		todo!()
+	}
+
+	async fn query_client_state(
+		&self,
+		at: Height,
+		client_id: ClientId,
+	) -> Result<QueryClientStateResponse, Self::Error> {
+		todo!()
+	}
+
+	async fn query_connection_end(
+		&self,
+		at: Height,
+		connection_id: ConnectionId,
+	) -> Result<QueryConnectionResponse, Self::Error> {
+		todo!()
+	}
+
+	async fn query_channel_end(
+		&self,
+		at: Height,
+		channel_id: ChannelId,
+		port_id: PortId,
+	) -> Result<QueryChannelResponse, Self::Error> {
+		todo!()
+	}
+
+	async fn query_proof(&self, at: Height, keys: Vec<Vec<u8>>) -> Result<Vec<u8>, Self::Error> {
+		todo!()
+	}
+
+	async fn query_packet_commitment(
+		&self,
+		at: Height,
+		port_id: &PortId,
+		channel_id: &ChannelId,
+		seq: u64,
+	) -> Result<QueryPacketCommitmentResponse, Self::Error> {
+		todo!()
+	}
+
+	async fn query_packet_acknowledgement(
+		&self,
+		at: Height,
+		port_id: &PortId,
+		channel_id: &ChannelId,
+		seq: u64,
+	) -> Result<QueryPacketAcknowledgementResponse, Self::Error> {
+		todo!()
+	}
+
+	async fn query_next_sequence_recv(
+		&self,
+		at: Height,
+		port_id: &PortId,
+		channel_id: &ChannelId,
+	) -> Result<QueryNextSequenceReceiveResponse, Self::Error> {
+		todo!()
+	}
+
+	async fn query_packet_receipt(
+		&self,
+		at: Height,
+		port_id: &PortId,
+		channel_id: &ChannelId,
+		seq: u64,
+	) -> Result<QueryPacketReceiptResponse, Self::Error> {
+		todo!()
+	}
+
+	async fn latest_height_and_timestamp(&self) -> Result<(Height, Timestamp), Self::Error> {
+		todo!()
+	}
+
+	async fn query_packet_commitments(
+		&self,
+		at: Height,
+		channel_id: ChannelId,
+		port_id: PortId,
+	) -> Result<Vec<u64>, Self::Error> {
+		todo!()
+	}
+
+	async fn query_packet_acknowledgements(
+		&self,
+		at: Height,
+		channel_id: ChannelId,
+		port_id: PortId,
+	) -> Result<Vec<u64>, Self::Error> {
+		todo!()
+	}
+
+	async fn query_unreceived_packets(
+		&self,
+		at: Height,
+		channel_id: ChannelId,
+		port_id: PortId,
+		seqs: Vec<u64>,
+	) -> Result<Vec<u64>, Self::Error> {
+		todo!()
+	}
+
+	async fn query_unreceived_acknowledgements(
+		&self,
+		at: Height,
+		channel_id: ChannelId,
+		port_id: PortId,
+		seqs: Vec<u64>,
+	) -> Result<Vec<u64>, Self::Error> {
+		todo!()
+	}
+
+	fn channel_whitelist(&self) -> Vec<(ChannelId, PortId)> {
+		todo!()
+	}
+
+	async fn query_connection_channels(
+		&self,
+		at: Height,
+		connection_id: &ConnectionId,
+	) -> Result<QueryChannelsResponse, Self::Error> {
+		todo!()
+	}
+
+	async fn query_send_packets(
+		&self,
+		channel_id: ChannelId,
+		port_id: PortId,
+		seqs: Vec<u64>,
+	) -> Result<Vec<PacketInfo>, Self::Error> {
+		todo!()
+	}
+
+	async fn query_recv_packets(
+		&self,
+		channel_id: ChannelId,
+		port_id: PortId,
+		seqs: Vec<u64>,
+	) -> Result<Vec<PacketInfo>, Self::Error> {
+		todo!()
+	}
+
+	fn expected_block_time(&self) -> Duration {
+		// Cosmos have an expected block time of 12 seconds
+		Duration::from_secs(10)
+	}
+
+	async fn query_client_update_time_and_height(
+		&self,
+		client_id: ClientId,
+		client_height: Height,
+	) -> Result<(Height, Timestamp), Self::Error> {
+		todo!()
+	}
+
+	async fn query_host_consensus_state_proof(
+		&self,
+		height: Height,
+	) -> Result<Option<Vec<u8>>, Self::Error> {
+		todo!()
+	}
+
+	async fn query_ibc_balance(&self) -> Result<Vec<PrefixedCoin>, Self::Error> {
+		todo!()
+	}
+
+	fn connection_prefix(&self) -> CommitmentPrefix {
+		todo!()
+	}
+
+	fn client_id(&self) -> ClientId {
+		self.client_id()
+	}
+
+	fn client_type(&self) -> ClientType {
+		todo!()
+	}
+
+	fn connection_id(&self) -> ConnectionId {
+		todo!()
+	}
+
+	async fn query_timestamp_at(&self, block_number: u64) -> Result<u64, Self::Error> {
+		todo!()
+	}
+
+	async fn query_clients(&self) -> Result<Vec<ClientId>, Self::Error> {
+		todo!()
+	}
+
+	async fn query_channels(&self) -> Result<Vec<(ChannelId, PortId)>, Self::Error> {
+		todo!()
+	}
+
+	async fn query_connection_using_client(
+		&self,
+		height: u32,
+		client_id: String,
+	) -> Result<Vec<IdentifiedConnection>, Self::Error> {
+		todo!()
+	}
+
+	fn is_update_required(
+		&self,
+		latest_height: u64,
+		latest_client_height_on_counterparty: u64,
+	) -> bool {
+		todo!()
+	}
+
+	async fn initialize_client_state(
+		&self,
+	) -> Result<(AnyClientState, AnyConsensusState), Self::Error> {
+		todo!()
+	}
+
+	async fn query_client_id_from_tx_hash(
+		&self,
+		tx_hash: H256,
+		block_hash: Option<H256>,
+	) -> Result<ClientId, Self::Error> {
+		todo!()
+	}
+}

--- a/hyperspace/cosmos/src/test_provider.rs
+++ b/hyperspace/cosmos/src/test_provider.rs
@@ -1,0 +1,32 @@
+use crate::CosmosClient;
+use futures::{Stream, StreamExt};
+use ibc::{
+	applications::transfer::{msgs::transfer::MsgTransfer, PrefixedCoin},
+	core::ics24_host::identifier::{ChannelId, PortId},
+};
+use pallet_ibc::Timeout;
+use primitives::{KeyProvider, TestProvider};
+use std::{pin::Pin, str::FromStr};
+
+#[async_trait::async_trait]
+impl<H> TestProvider for CosmosClient<H>
+where
+	Self: KeyProvider,
+	H: Clone + Send + Sync + 'static,
+{
+	async fn send_transfer(&self, transfer: MsgTransfer<PrefixedCoin>) -> Result<(), Self::Error> {
+		Ok(())
+	}
+
+	async fn send_ping(&self, channel_id: ChannelId, timeout: Timeout) -> Result<(), Self::Error> {
+		Ok(())
+	}
+
+	async fn subscribe_blocks(&self) -> Pin<Box<dyn Stream<Item = u64> + Send + Sync>> {
+		todo!()
+	}
+
+	fn set_channel_whitelist(&mut self, channel_whitelist: Vec<(ChannelId, PortId)>) {
+		todo!()
+	}
+}

--- a/hyperspace/cosmos/src/utils.rs
+++ b/hyperspace/cosmos/src/utils.rs
@@ -1,0 +1,32 @@
+use crate::error::Error;
+use ibc::core::ics02_client::events::Attributes as ClientAttributes;
+use tendermint_rpc::abci::Event as AbciEvent;
+
+pub fn client_extract_attributes_from_tx(event: &AbciEvent) -> Result<ClientAttributes, Error> {
+	let mut attr = ClientAttributes::default();
+
+	for tag in &event.attributes {
+		let key = tag.key.as_ref();
+		let value = tag.value.as_ref();
+		match key {
+			"client_id" => {
+				attr.client_id = value
+					.parse()
+					.map_err(|e| Error::from(format!("Failed to parse client id {:?}", e)))?
+			},
+			"client_type" => {
+				attr.client_type = value
+					.parse()
+					.map_err(|e| Error::from(format!("Failed to parse client type {:?}", e)))?
+			},
+			"consensus_height" => {
+				attr.consensus_height = value
+					.parse()
+					.map_err(|e| Error::from(format!("Failed to parse consensus height {:?}", e)))?
+			},
+			_ => {},
+		}
+	}
+
+	Ok(attr)
+}

--- a/hyperspace/parachain/Cargo.toml
+++ b/hyperspace/parachain/Cargo.toml
@@ -60,7 +60,7 @@ sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "polka
 # composable
 ibc = { path = "../../ibc/modules", features = [] }
 ibc-proto = { path = "../../ibc/proto" }
-tendermint-proto = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8" }
+tendermint-proto = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426" }
 light-client-common = { path = "../../light-clients/common" }
 ibc-rpc = { path = "../../contracts/pallet-ibc/rpc" }
 pallet-ibc = { path = "../../contracts/pallet-ibc" }

--- a/hyperspace/parachain/src/chain.rs
+++ b/hyperspace/parachain/src/chain.rs
@@ -25,6 +25,7 @@ use crate::{
 };
 use finality_grandpa_rpc::GrandpaApiClient;
 use subxt::tx::{PlainTip, PolkadotExtrinsicParamsBuilder};
+use subxt::ext::sp_core;
 
 type GrandpaJustification = grandpa_light_client_primitives::justification::GrandpaJustification<
 	polkadot_core_primitives::Header,
@@ -164,11 +165,10 @@ where
 			},
 		}
 	}
-
 	async fn submit(
 		&self,
 		messages: Vec<Any>,
-	) -> Result<(sp_core::H256, Option<sp_core::H256>), Error> {
+	) -> Result<(Self::Hash, Option<Self::Hash>), Error> {
 		let messages = messages
 			.into_iter()
 			.map(|msg| RawAny { type_url: msg.type_url.as_bytes().to_vec(), value: msg.value })

--- a/hyperspace/parachain/src/provider.rs
+++ b/hyperspace/parachain/src/provider.rs
@@ -72,6 +72,7 @@ where
 		From<BaseExtrinsicParamsBuilder<T, PlainTip>> + Send + Sync,
 {
 	type FinalityEvent = FinalityEvent;
+	type Hash = subxt::ext::sp_core::H256;
 	type Error = Error;
 
 	async fn query_latest_ibc_events<C>(

--- a/hyperspace/primitives/src/lib.rs
+++ b/hyperspace/primitives/src/lib.rs
@@ -15,8 +15,6 @@ use ibc_proto::{
 		connection::v1::QueryConnectionResponse,
 	},
 };
-use subxt::ext::sp_core;
-
 use crate::error::Error;
 #[cfg(feature = "testing")]
 use ibc::applications::transfer::msgs::transfer::MsgTransfer;
@@ -83,6 +81,8 @@ pub fn apply_prefix(mut commitment_prefix: Vec<u8>, path: String) -> Vec<u8> {
 pub trait IbcProvider {
 	/// Finality event type, passed on to [`Chain::query_latest_ibc_events`]
 	type FinalityEvent;
+
+	type Hash;
 
 	/// Error type, just needs to implement standard error trait.
 	type Error: std::error::Error + From<String> + Send + Sync + 'static;
@@ -306,8 +306,8 @@ pub trait IbcProvider {
 	/// Should find client id that was created in this transaction
 	async fn query_client_id_from_tx_hash(
 		&self,
-		tx_hash: sp_core::H256,
-		block_hash: Option<sp_core::H256>,
+		tx_hash: Self::Hash,
+		block_hash: Option<Self::Hash>,
 	) -> Result<ClientId, Self::Error>;
 }
 
@@ -365,7 +365,7 @@ pub trait Chain: IbcProvider + KeyProvider + Send + Sync {
 	async fn submit(
 		&self,
 		messages: Vec<Any>,
-	) -> Result<(sp_core::H256, Option<sp_core::H256>), Self::Error>;
+	) -> Result<(Self::Hash, Option<Self::Hash>), Self::Error>;
 }
 
 /// Returns undelivered packet sequences that have been sent out from

--- a/hyperspace/primitives/src/lib.rs
+++ b/hyperspace/primitives/src/lib.rs
@@ -82,7 +82,7 @@ pub trait IbcProvider {
 	/// Finality event type, passed on to [`Chain::query_latest_ibc_events`]
 	type FinalityEvent;
 
-	type Hash;
+	type Hash: core::fmt::Debug;
 
 	/// Error type, just needs to implement standard error trait.
 	type Error: std::error::Error + From<String> + Send + Sync + 'static;

--- a/hyperspace/testsuite/Cargo.toml
+++ b/hyperspace/testsuite/Cargo.toml
@@ -19,8 +19,8 @@ tonic = { version = "0.7.2", features = ["tls", "tls-roots"] }
 
 ibc = { path = "../../ibc/modules" }
 ibc-proto = { path = "../../ibc/proto" }
-tendermint-proto = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8" }
-tendermint-rpc   = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", features = ["http-client", "websocket-client"] }
+tendermint-proto = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426" }
+tendermint-rpc   = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426", features = ["http-client", "websocket-client"] }
 
 hyperspace-core = { path = "../core", features = ["testing"] }
 hyperspace-primitives = { path = "../primitives", features = ["testing"] }

--- a/hyperspace/testsuite/Cargo.toml
+++ b/hyperspace/testsuite/Cargo.toml
@@ -29,7 +29,7 @@ pallet-ibc = { path = "../../contracts/pallet-ibc" }
 [dev-dependencies]
 # hyperspace-core = { path = "../core", features = ["testing", "build-metadata-from-ws"] }
 # hyperspace-parachain = { path = "../parachain", features = ["testing", "build-metadata-from-ws"] }
-# hyperspace-cosmos = { path = "../cosmos", package = "hyperspace-cosmos", features = ["testing"] }
+hyperspace-cosmos = { path = "../cosmos", package = "hyperspace-cosmos", features = ["testing"] }
 
 # substrate
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", features = ["full_crypto"] }

--- a/hyperspace/testsuite/Cargo.toml
+++ b/hyperspace/testsuite/Cargo.toml
@@ -15,18 +15,22 @@ anyhow = "1.0.66"
 async-trait = "0.1.58"
 futures = "0.3.24"
 json = { version = "1.0.85", package = "serde_json" }
+tonic = { version = "0.7.2", features = ["tls", "tls-roots"] }
 
 ibc = { path = "../../ibc/modules" }
 ibc-proto = { path = "../../ibc/proto" }
 tendermint-proto = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8" }
+tendermint-rpc   = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", features = ["http-client", "websocket-client"] }
 
 hyperspace-core = { path = "../core", features = ["testing"] }
 hyperspace-primitives = { path = "../primitives", features = ["testing"] }
 pallet-ibc = { path = "../../contracts/pallet-ibc" }
 
 [dev-dependencies]
-hyperspace-core = { path = "../core", features = ["testing", "build-metadata-from-ws"] }
-hyperspace-parachain = { path = "../parachain", features = ["testing", "build-metadata-from-ws"] }
+# hyperspace-core = { path = "../core", features = ["testing", "build-metadata-from-ws"] }
+# hyperspace-parachain = { path = "../parachain", features = ["testing", "build-metadata-from-ws"] }
+# hyperspace-cosmos = { path = "../cosmos", package = "hyperspace-cosmos", features = ["testing"] }
+
 # substrate
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", features = ["full_crypto"] }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
@@ -37,3 +41,8 @@ subxt = { git = "https://github.com/paritytech/subxt", rev = "1736f618d940a69ab2
 # We need this so the tests run sequentially
 [[test]]
 name = "parachain_parachain"
+feature = ["dep:hyperspace-parachain"]
+
+[[test]]
+name = "cosmos_cosmos"
+feature = ["hyperspace-cosmos"]

--- a/hyperspace/testsuite/tests/cosmos_cosmos.rs
+++ b/hyperspace/testsuite/tests/cosmos_cosmos.rs
@@ -1,0 +1,40 @@
+use std::{marker::PhantomData, str::FromStr};
+
+use cosmos::{CosmosClient, CosmosClientConfig};
+use futures::StreamExt;
+use hyperspace::logging;
+use hyperspace_primitives::{mock::LocalClientTypes, IbcProvider, KeyProvider};
+use hyperspace_testsuite::{
+	ibc_channel_close, ibc_messaging_packet_height_timeout_with_connection_delay,
+	ibc_messaging_packet_timeout_on_channel_close,
+	ibc_messaging_packet_timestamp_timeout_with_connection_delay,
+	ibc_messaging_with_connection_delay,
+};
+use ibc::{core::ics02_client::msgs::create_client::MsgCreateAnyClient, tx_msg::Msg};
+use subxt::tx::SubstrateExtrinsicParams;
+
+use tendermint_proto::Protobuf;
+use tendermint_rpc::{endpoint::broadcast::tx_sync::Response, Client, HttpClient, Url};
+
+async fn setup_clients<H: Clone + Send + Sync + 'static>() -> (CosmosClient<H>, CosmosClient<H>) {
+	log::info!(target: "hyperspace", "=========================== Starting Test ===========================");
+	todo!()
+}
+
+#[tokio::test]
+async fn cosmos_to_cosmos_ibc_messaging_full_integration_test() {
+	logging::setup_logging();
+	let (mut chain_a, mut chain_b) = setup_clients::<u32>().await;
+
+	// no timeouts + connection delay
+	ibc_messaging_with_connection_delay(&mut chain_a, &mut chain_b).await;
+
+	// timeouts + connection delay
+	ibc_messaging_packet_height_timeout_with_connection_delay(&mut chain_a, &mut chain_b).await;
+	ibc_messaging_packet_timestamp_timeout_with_connection_delay(&mut chain_a, &mut
+	chain_b).await;
+
+	// channel closing semantics
+	ibc_messaging_packet_timeout_on_channel_close(&mut chain_a, &mut chain_b).await;
+	ibc_channel_close(&mut chain_a, &mut chain_b).await;
+}

--- a/hyperspace/testsuite/tests/cosmos_cosmos.rs
+++ b/hyperspace/testsuite/tests/cosmos_cosmos.rs
@@ -31,7 +31,7 @@ async fn setup_clients<H: Clone + Send + Sync + 'static>() -> (CosmosClient<H>, 
 		connection_id: None,
 		account_prefix: "cosmos".to_string(),
 		store_prefix: "ibc".to_string(),
-		key_name: "testkey".to_string(),
+		key_name: "wallet".to_string(),
 	};
 
 	let config_b = CosmosClientConfig {
@@ -44,7 +44,7 @@ async fn setup_clients<H: Clone + Send + Sync + 'static>() -> (CosmosClient<H>, 
 		connection_id: None,
 		account_prefix: "cosmos".to_string(),
 		store_prefix: "ibc".to_string(),
-		key_name: "testkey".to_string(),
+		key_name: "wallet".to_string(),
 	};
 
 	let mut chain_a = CosmosClient::<H>::new(config_a).await.unwrap();
@@ -76,7 +76,7 @@ async fn setup_clients<H: Clone + Send + Sync + 'static>() -> (CosmosClient<H>, 
 	log::info!(target: "hyperspace", "Timestamp at height 2000 on chain_a: {:?}", time);
 	let channels = chain_a.query_channels().await.unwrap();
 	log::info!(target: "hyperspace", "Channels on chain_a: {:?}", channels);
-	
+
 	{
 		// Get initial tendermint state
 		// let (client_state, consensus_state) =

--- a/hyperspace/testsuite/tests/cosmos_cosmos.rs
+++ b/hyperspace/testsuite/tests/cosmos_cosmos.rs
@@ -58,6 +58,17 @@ async fn setup_clients<H: Clone + Send + Sync + 'static>() -> (CosmosClient<H>, 
 	chain_b.rpc_client.status().await.unwrap();
 	log::info!(target: "hyperspace", "Cosmos chains are ready");
 
+	// Check if the clients are already created
+	let clients_on_a = chain_a.query_clients().await.unwrap();
+	log::info!(target: "hyperspace", "Clients on chain_a: {:?}", clients_on_a);
+	let clients_on_b = chain_b.query_clients().await.unwrap();
+	log::info!(target: "hyperspace", "Clients on chain_b: {:?}", clients_on_b);
+
+	if !clients_on_a.is_empty() && !clients_on_b.is_empty() {
+		chain_a.set_client_id(clients_on_b[0].clone());
+		chain_b.set_client_id(clients_on_b[0].clone());
+		return (chain_a, chain_b);
+	}
 	(chain_a, chain_b)
 }
 

--- a/hyperspace/testsuite/tests/cosmos_cosmos.rs
+++ b/hyperspace/testsuite/tests/cosmos_cosmos.rs
@@ -64,11 +64,63 @@ async fn setup_clients<H: Clone + Send + Sync + 'static>() -> (CosmosClient<H>, 
 	let clients_on_b = chain_b.query_clients().await.unwrap();
 	log::info!(target: "hyperspace", "Clients on chain_b: {:?}", clients_on_b);
 
-	if !clients_on_a.is_empty() && !clients_on_b.is_empty() {
-		chain_a.set_client_id(clients_on_b[0].clone());
-		chain_b.set_client_id(clients_on_b[0].clone());
-		return (chain_a, chain_b);
-	}
+	// if !clients_on_a.is_empty() && !clients_on_b.is_empty() {
+	// 	chain_a.set_client_id(clients_on_b[0].clone());
+	// 	chain_b.set_client_id(clients_on_b[0].clone());
+	// 	return (chain_a, chain_b);
+	// }
+
+	let height = chain_a.latest_height_and_timestamp().await.unwrap();
+	log::info!(target: "hyperspace", "Latest height on chain_a: {:?}", height);
+	let time = chain_a.query_timestamp_at(2000).await.unwrap();
+	log::info!(target: "hyperspace", "Timestamp at height 2000 on chain_a: {:?}", time);
+	
+	{
+		// Get initial tendermint state
+		// let (client_state, consensus_state) =
+		// 	chain_b.construct_tendermint_client_state().await.unwrap();
+
+		// 	// Create client message is the same for both chains
+		// 	let msg_create_client = MsgCreateAnyClient::<LocalClientTypes> {
+		// 		client_state: client_state.clone(),
+		// 		consensus_state,
+		// 		signer: chain_a.account_id(),
+		// 	};
+
+		// 	let msg = pallet_ibc::Any {
+		// 		type_url: msg_create_client.type_url().as_bytes().to_vec(),
+		// 		value: msg_create_client.encode_vec(),
+		// 	};
+		// 	let client_id_b_on_a = chain_a
+		// 		.submit_create_client_msg(msg.clone())
+		// 		.await
+		// 		.expect("Client was not created successfully");
+		// 	chain_b.set_client_id(client_id_b_on_a.clone());
+	};
+
+	{
+		// 	// Get initial tendermint state
+		// let (client_state, consensus_state) =
+		// 	chain_a.construct_tendermint_client_state().await.unwrap();
+
+		// 	// Create client message is the same for both chains
+		// 	let msg_create_client = MsgCreateAnyClient::<LocalClientTypes> {
+		// 		client_state: client_state.clone(),
+		// 		consensus_state,
+		// 		signer: chain_a.account_id(),
+		// 	};
+
+		// 	let msg = pallet_ibc::Any {
+		// 		type_url: msg_create_client.type_url().as_bytes().to_vec(),
+		// 		value: msg_create_client.encode_vec(),
+		// 	};
+		// 	let client_id_a_on_b = chain_b
+		// 		.submit_create_client_msg(msg)
+		// 		.await
+		// 		.expect("Client was not created successfully");
+		// 	chain_a.set_client_id(client_id_a_on_b.clone());
+	};
+
 	(chain_a, chain_b)
 }
 

--- a/hyperspace/testsuite/tests/cosmos_cosmos.rs
+++ b/hyperspace/testsuite/tests/cosmos_cosmos.rs
@@ -1,8 +1,8 @@
 use std::{marker::PhantomData, str::FromStr};
 
-use hyperspace_cosmos::{CosmosClient, CosmosClientConfig};
 use futures::StreamExt;
 use hyperspace_core::logging;
+use hyperspace_cosmos::{CosmosClient, CosmosClientConfig};
 use hyperspace_primitives::{mock::LocalClientTypes, IbcProvider, KeyProvider};
 use hyperspace_testsuite::{
 	ibc_channel_close, ibc_messaging_packet_height_timeout_with_connection_delay,
@@ -18,7 +18,7 @@ use tendermint_rpc::{endpoint::broadcast::tx_sync::Response, Client, HttpClient,
 
 async fn setup_clients<H: Clone + Send + Sync + 'static>() -> (CosmosClient<H>, CosmosClient<H>) {
 	log::info!(target: "hyperspace", "=========================== Starting Test ===========================");
-	
+
 	// Create client configurations
 	// Parameters have been set up to work with local nodes according to https://hermes.informal.systems/tutorials
 	let config_a = CosmosClientConfig {
@@ -49,6 +49,15 @@ async fn setup_clients<H: Clone + Send + Sync + 'static>() -> (CosmosClient<H>, 
 
 	let mut chain_a = CosmosClient::<H>::new(config_a).await.unwrap();
 	let mut chain_b = CosmosClient::<H>::new(config_b).await.unwrap();
+
+	// Wait until for cosmos chains to start producing blocks
+	log::info!(target: "hyperspace", "Waiting for block production from cosmos chains");
+	chain_a.rpc_client.health().await.unwrap();
+	chain_a.rpc_client.status().await.unwrap();
+	chain_b.rpc_client.health().await.unwrap();
+	chain_b.rpc_client.status().await.unwrap();
+	log::info!(target: "hyperspace", "Cosmos chains are ready");
+
 	(chain_a, chain_b)
 }
 

--- a/hyperspace/testsuite/tests/cosmos_cosmos.rs
+++ b/hyperspace/testsuite/tests/cosmos_cosmos.rs
@@ -1,8 +1,8 @@
 use std::{marker::PhantomData, str::FromStr};
 
-use cosmos::{CosmosClient, CosmosClientConfig};
+use hyperspace_cosmos::{CosmosClient, CosmosClientConfig};
 use futures::StreamExt;
-use hyperspace::logging;
+use hyperspace_core::logging;
 use hyperspace_primitives::{mock::LocalClientTypes, IbcProvider, KeyProvider};
 use hyperspace_testsuite::{
 	ibc_channel_close, ibc_messaging_packet_height_timeout_with_connection_delay,
@@ -18,23 +18,55 @@ use tendermint_rpc::{endpoint::broadcast::tx_sync::Response, Client, HttpClient,
 
 async fn setup_clients<H: Clone + Send + Sync + 'static>() -> (CosmosClient<H>, CosmosClient<H>) {
 	log::info!(target: "hyperspace", "=========================== Starting Test ===========================");
-	todo!()
+	
+	// Create client configurations
+	// Parameters have been set up to work with local nodes according to https://hermes.informal.systems/tutorials
+	let config_a = CosmosClientConfig {
+		name: "chain_a".to_string(),
+		chain_id: "ibc-0".to_string(),
+		rpc_url: Url::from_str("http://127.0.0.1:27010").unwrap(),
+		grpc_url: Url::from_str("http://127.0.0.1:27012").unwrap(),
+		websocket_url: Url::from_str("ws://127.0.0.1:27010/websocket").unwrap(),
+		client_id: Some("7-tendermint".to_string()),
+		connection_id: None,
+		account_prefix: "cosmos".to_string(),
+		store_prefix: "ibc".to_string(),
+		key_name: "testkey".to_string(),
+	};
+
+	let config_b = CosmosClientConfig {
+		name: "chain_b".to_string(),
+		chain_id: "ibc-1".to_string(),
+		rpc_url: Url::from_str("http://127.0.0.1:27020").unwrap(),
+		grpc_url: Url::from_str("http://127.0.0.1:27022").unwrap(),
+		websocket_url: Url::from_str("ws://127.0.0.1:27020/websocket").unwrap(),
+		client_id: Some("7-tendermint".to_string()),
+		connection_id: None,
+		account_prefix: "cosmos".to_string(),
+		store_prefix: "ibc".to_string(),
+		key_name: "testkey".to_string(),
+	};
+
+	let mut chain_a = CosmosClient::<H>::new(config_a).await.unwrap();
+	let mut chain_b = CosmosClient::<H>::new(config_b).await.unwrap();
+	(chain_a, chain_b)
 }
 
 #[tokio::test]
 async fn cosmos_to_cosmos_ibc_messaging_full_integration_test() {
 	logging::setup_logging();
 	let (mut chain_a, mut chain_b) = setup_clients::<u32>().await;
+	// Run tests sequentially
 
 	// no timeouts + connection delay
-	ibc_messaging_with_connection_delay(&mut chain_a, &mut chain_b).await;
+	// ibc_messaging_with_connection_delay(&mut chain_a, &mut chain_b).await;
 
-	// timeouts + connection delay
-	ibc_messaging_packet_height_timeout_with_connection_delay(&mut chain_a, &mut chain_b).await;
-	ibc_messaging_packet_timestamp_timeout_with_connection_delay(&mut chain_a, &mut
-	chain_b).await;
+	// // timeouts + connection delay
+	// ibc_messaging_packet_height_timeout_with_connection_delay(&mut chain_a, &mut chain_b).await;
+	// ibc_messaging_packet_timestamp_timeout_with_connection_delay(&mut chain_a, &mut
+	// chain_b).await;
 
-	// channel closing semantics
-	ibc_messaging_packet_timeout_on_channel_close(&mut chain_a, &mut chain_b).await;
-	ibc_channel_close(&mut chain_a, &mut chain_b).await;
+	// // channel closing semantics
+	// ibc_messaging_packet_timeout_on_channel_close(&mut chain_a, &mut chain_b).await;
+	// ibc_channel_close(&mut chain_a, &mut chain_b).await;
 }

--- a/hyperspace/testsuite/tests/cosmos_cosmos.rs
+++ b/hyperspace/testsuite/tests/cosmos_cosmos.rs
@@ -74,6 +74,8 @@ async fn setup_clients<H: Clone + Send + Sync + 'static>() -> (CosmosClient<H>, 
 	log::info!(target: "hyperspace", "Latest height on chain_a: {:?}", height);
 	let time = chain_a.query_timestamp_at(2000).await.unwrap();
 	log::info!(target: "hyperspace", "Timestamp at height 2000 on chain_a: {:?}", time);
+	let channels = chain_a.query_channels().await.unwrap();
+	log::info!(target: "hyperspace", "Channels on chain_a: {:?}", channels);
 	
 	{
 		// Get initial tendermint state

--- a/hyperspace/testsuite/tests/cosmos_cosmos.rs
+++ b/hyperspace/testsuite/tests/cosmos_cosmos.rs
@@ -79,9 +79,9 @@ async fn setup_clients<H: Clone + Send + Sync + 'static>() -> (CosmosClient<H>, 
 
 	{
 		// Get initial tendermint state
-		// let (client_state, consensus_state) =
-		// 	chain_b.construct_tendermint_client_state().await.unwrap();
-
+		let (client_state, consensus_state) =
+			chain_b.construct_tendermint_client_state().await.unwrap();
+			
 		// 	// Create client message is the same for both chains
 		// 	let msg_create_client = MsgCreateAnyClient::<LocalClientTypes> {
 		// 		client_state: client_state.clone(),
@@ -101,9 +101,9 @@ async fn setup_clients<H: Clone + Send + Sync + 'static>() -> (CosmosClient<H>, 
 	};
 
 	{
-		// 	// Get initial tendermint state
-		// let (client_state, consensus_state) =
-		// 	chain_a.construct_tendermint_client_state().await.unwrap();
+			// Get initial tendermint state
+		let (client_state, consensus_state) =
+			chain_a.construct_tendermint_client_state().await.unwrap();
 
 		// 	// Create client message is the same for both chains
 		// 	let msg_create_client = MsgCreateAnyClient::<LocalClientTypes> {

--- a/hyperspace/testsuite/tests/cosmos_cosmos.rs
+++ b/hyperspace/testsuite/tests/cosmos_cosmos.rs
@@ -81,46 +81,47 @@ async fn setup_clients<H: Clone + Send + Sync + 'static>() -> (CosmosClient<H>, 
 		// Get initial tendermint state
 		let (client_state, consensus_state) =
 			chain_b.construct_tendermint_client_state().await.unwrap();
-			
-		// 	// Create client message is the same for both chains
-		// 	let msg_create_client = MsgCreateAnyClient::<LocalClientTypes> {
-		// 		client_state: client_state.clone(),
-		// 		consensus_state,
-		// 		signer: chain_a.account_id(),
-		// 	};
 
-		// 	let msg = pallet_ibc::Any {
-		// 		type_url: msg_create_client.type_url().as_bytes().to_vec(),
-		// 		value: msg_create_client.encode_vec(),
-		// 	};
-		// 	let client_id_b_on_a = chain_a
-		// 		.submit_create_client_msg(msg.clone())
-		// 		.await
-		// 		.expect("Client was not created successfully");
-		// 	chain_b.set_client_id(client_id_b_on_a.clone());
+		// Create client message is the same for both chains
+		let msg_create_client = MsgCreateAnyClient::<LocalClientTypes> {
+			client_state: client_state.clone(),
+			consensus_state,
+			signer: chain_a.account_id(),
+		};
+
+		// let msg = pallet_ibc::Any {
+		// 	type_url: msg_create_client.type_url().as_bytes().to_vec(),
+		// 	value: msg_create_client.encode_vec(),
+		// };
+		// let client_id_b_on_a = chain_a
+		// 	.submit_create_client_msg(msg.clone())
+		// 	.await
+		// 	.expect("Client was not created successfully");
+		// chain_b.set_client_id(client_id_b_on_a.clone());
 	};
 
 	{
-			// Get initial tendermint state
+		// Get initial tendermint state
 		let (client_state, consensus_state) =
 			chain_a.construct_tendermint_client_state().await.unwrap();
 
-		// 	// Create client message is the same for both chains
-		// 	let msg_create_client = MsgCreateAnyClient::<LocalClientTypes> {
-		// 		client_state: client_state.clone(),
-		// 		consensus_state,
-		// 		signer: chain_a.account_id(),
-		// 	};
+		// Create client message is the same for both chains
+		let msg_create_client = MsgCreateAnyClient::<LocalClientTypes> {
+			client_state: client_state.clone(),
+			consensus_state,
+			signer: chain_a.account_id(),
+		};
 
-		// 	let msg = pallet_ibc::Any {
-		// 		type_url: msg_create_client.type_url().as_bytes().to_vec(),
-		// 		value: msg_create_client.encode_vec(),
-		// 	};
-		// 	let client_id_a_on_b = chain_b
-		// 		.submit_create_client_msg(msg)
-		// 		.await
-		// 		.expect("Client was not created successfully");
-		// 	chain_a.set_client_id(client_id_a_on_b.clone());
+		// let msg = pallet_ibc::Any {
+		// 	type_url: msg_create_client.type_url().as_bytes().to_vec(),
+		// 	value: msg_create_client.encode_vec(),
+		// };
+
+		// let client_id_a_on_b = chain_b
+		// 	.submit_create_client_msg(msg)
+		// 	.await
+		// 	.expect("Client was not created successfully");
+		// chain_a.set_client_id(client_id_a_on_b.clone());
 	};
 
 	(chain_a, chain_b)

--- a/ibc/modules/Cargo.toml
+++ b/ibc/modules/Cargo.toml
@@ -55,13 +55,13 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 sha2 = { version = "0.10.2", optional = true }
 
 [dependencies.tendermint]
-git = "https://github.com/composableFi/tendermint-rs"
-rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8"
+git = "https://github.com/farhad-shabani/tendermint-rs"
+rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426"
 default-features = false
 
 [dependencies.tendermint-proto]
-git = "https://github.com/composableFi/tendermint-rs"
-rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8"
+git = "https://github.com/farhad-shabani/tendermint-rs"
+rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426"
 default-features = false
 
 [dev-dependencies]

--- a/ibc/proto/Cargo.toml
+++ b/ibc/proto/Cargo.toml
@@ -31,8 +31,8 @@ schemars    = { version = "0.8", optional = true }
 base64      = { version = "0.13", default-features = false, features = ["alloc"] }
 
 [dependencies.tendermint-proto]
-git = "https://github.com/composableFi/tendermint-rs"
-rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8"
+git = "https://github.com/farhad-shabani/tendermint-rs"
+rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426"
 default-features = false
 
 [features]

--- a/light-clients/ics07-tendermint/Cargo.toml
+++ b/light-clients/ics07-tendermint/Cargo.toml
@@ -13,7 +13,6 @@ std = []
 [dependencies]
 ibc = { path = "../../ibc/modules", default-features = false }
 ibc-proto = { path = "../../ibc/proto", default-features = false }
-
 ics23 = { git = "https://github.com/composablefi/ics23", rev = "b500a5c6068eb53c83c4c6c13bd9d8c25e0bf927", default-features = false }
 time = { version = "0.3", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
@@ -24,18 +23,18 @@ subtle-encoding = { version = "0.5", default-features = false }
 flex-error = { version = "0.4.4", default-features = false }
 
 [dependencies.tendermint]
-git = "https://github.com/composableFi/tendermint-rs"
-rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8"
+git = "https://github.com/farhad-shabani/tendermint-rs"
+rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426"
 default-features = false
 
 [dependencies.tendermint-proto]
-git = "https://github.com/composableFi/tendermint-rs"
-rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8"
+git = "https://github.com/farhad-shabani/tendermint-rs"
+rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426"
 default-features = false
 
 [dependencies.tendermint-light-client-verifier]
-git = "https://github.com/composableFi/tendermint-rs"
-rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8"
+git = "https://github.com/farhad-shabani/tendermint-rs"
+rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426"
 default-features = false
 
 [dev-dependencies]
@@ -46,7 +45,7 @@ tracing-subscriber = { version = "0.3.11", features = ["fmt", "env-filter", "jso
 test-log = { version = "0.2.10", features = ["trace"] }
 modelator = "0.4.2"
 sha2 = { version = "0.10.2" }
-tendermint-rpc = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", features = ["http-client", "websocket-client"] }
-tendermint-testgen = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8" } # Needed for generating (synthetic) light blocks.
+tendermint-rpc = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426", features = ["http-client", "websocket-client"] }
+tendermint-testgen = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426" } # Needed for generating (synthetic) light blocks.
 log = "0.4.17"
 tracing = "0.1.36"

--- a/light-clients/ics07-tendermint/src/client_def.rs
+++ b/light-clients/ics07-tendermint/src/client_def.rs
@@ -75,7 +75,7 @@ where
 							header.height().revision_number,
 						)
 						.to_string(),
-					))
+					));
 				}
 
 				// Check if a consensus state is already installed; if so skip
@@ -92,7 +92,7 @@ where
 						if cs == header_consensus_state {
 							// Header is already installed and matches the incoming
 							// header (already verified)
-							return Ok(())
+							return Ok(());
 						}
 						Some(cs)
 					},
@@ -139,14 +139,16 @@ where
 
 				match verdict {
 					Verdict::Success => {},
-					Verdict::NotEnoughTrust(voting_power_tally) =>
+					Verdict::NotEnoughTrust(voting_power_tally) => {
 						return Err(Error::not_enough_trusted_vals_signed(format!(
 							"voting power tally: {}",
 							voting_power_tally
 						))
-						.into()),
-					Verdict::Invalid(detail) =>
-						return Err(Error::verification_error(detail).into()),
+						.into())
+					},
+					Verdict::Invalid(detail) => {
+						return Err(Error::verification_error(detail).into())
+					},
 				}
 			},
 			ClientMessage::Misbehaviour(misbehaviour) => {
@@ -228,7 +230,7 @@ where
 							if header_consensus_state == cs {
 								// Header is already installed and matches the incoming
 								// header (already verified)
-								return Ok(false)
+								return Ok(false);
 							}
 							Some(cs)
 						},
@@ -240,7 +242,7 @@ where
 				// client and return the installed consensus state.
 				if let Some(cs) = existing_consensus_state {
 					if cs != header_consensus_state {
-						return Ok(true)
+						return Ok(true);
 					}
 				}
 
@@ -261,14 +263,14 @@ where
 					if let Some(next_cs) = maybe_next_cs {
 						// New (untrusted) header timestamp cannot occur after next
 						// consensus state's height
-						if Timestamp::from(header.signed_header.header().time).nanoseconds() >
-							next_cs.timestamp().nanoseconds()
+						if Timestamp::from(header.signed_header.header().time).nanoseconds()
+							> next_cs.timestamp().nanoseconds()
 						{
 							return Err(Error::header_timestamp_too_high(
 								header.signed_header.header().time.to_string(),
 								next_cs.timestamp().to_string(),
 							)
-							.into())
+							.into());
 						}
 					}
 				}
@@ -293,7 +295,7 @@ where
 								header.signed_header.header().time.to_string(),
 								prev_cs.timestamp.to_string(),
 							)
-							.into())
+							.into());
 						}
 					}
 				}

--- a/light-clients/ics07-tendermint/src/lib.rs
+++ b/light-clients/ics07-tendermint/src/lib.rs
@@ -28,7 +28,7 @@ mod query;
 /// Host functions that allow the light client verify cryptographic proofs in native.
 pub trait HostFunctionsProvider:
 	ics23::HostFunctionsProvider
-	+ tendermint_light_client_verifier::host_functions::HostFunctionsProvider
+	+ tendermint_light_client_verifier::host_functions::CryptoProvider
 	+ Debug
 	+ Clone
 	+ Send

--- a/light-clients/ics07-tendermint/src/mock/mod.rs
+++ b/light-clients/ics07-tendermint/src/mock/mod.rs
@@ -30,7 +30,7 @@ use ibc::{
 };
 use ibc_derive::{ClientDef, ClientMessage, ClientState, ConsensusState};
 use ibc_proto::google::protobuf::Any;
-use tendermint_light_client_verifier::host_functions::HostFunctionsProvider as TendermintHostFunctionsProvider;
+use tendermint_light_client_verifier::host_functions::CryptoProvider as TmCryptoProvider;
 use tendermint_proto::Protobuf;
 
 pub const MOCK_CLIENT_STATE_TYPE_URL: &str = "/ibc.mock.ClientState";
@@ -162,12 +162,12 @@ impl ics23::HostFunctionsProvider for Crypto {
 	}
 }
 
-impl TendermintHostFunctionsProvider for Crypto {
+impl TmCryptoProvider for Crypto {
 	fn sha2_256(_preimage: &[u8]) -> [u8; 32] {
 		unimplemented!()
 	}
 
-	fn ed25519_verify(_sig: &[u8], _msg: &[u8], _pub_key: &[u8]) -> bool {
+	fn ed25519_verify(_sig: &[u8], _msg: &[u8], _pub_key: &[u8]) ->  bool {
 		unimplemented!()
 	}
 

--- a/light-clients/ics10-grandpa/Cargo.toml
+++ b/light-clients/ics10-grandpa/Cargo.toml
@@ -60,13 +60,13 @@ sp-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch 
 finality-grandpa = { version = "0.16.0", default-features = false }
 
 [dependencies.tendermint]
-git = "https://github.com/composableFi/tendermint-rs"
-rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8"
+git = "https://github.com/farhad-shabani/tendermint-rs"
+rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426"
 default-features = false
 
 [dependencies.tendermint-proto]
-git = "https://github.com/composableFi/tendermint-rs"
-rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8"
+git = "https://github.com/farhad-shabani/tendermint-rs"
+rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426"
 default-features = false
 
 [dev-dependencies]

--- a/light-clients/ics11-beefy/Cargo.toml
+++ b/light-clients/ics11-beefy/Cargo.toml
@@ -63,13 +63,13 @@ derive_more = { version = "0.99.17", default-features = false, features = ["from
 primitive-types = { version = "0.11.1", default-features = false }
 
 [dependencies.tendermint]
-git = "https://github.com/composableFi/tendermint-rs"
-rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8"
+git = "https://github.com/farhad-shabani/tendermint-rs"
+rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426"
 default-features = false
 
 [dependencies.tendermint-proto]
-git = "https://github.com/composableFi/tendermint-rs"
-rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8"
+git = "https://github.com/farhad-shabani/tendermint-rs"
+rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426"
 default-features = false
 
 [dev-dependencies]

--- a/light-clients/ics13-near/Cargo.toml
+++ b/light-clients/ics13-near/Cargo.toml
@@ -51,13 +51,13 @@ sha3 = { version = "0.10.1", optional = true }
 ripemd = { version = "0.1.1", optional = true }
 
 [dependencies.tendermint]
-git = "https://github.com/composableFi/tendermint-rs"
-rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8"
+git = "https://github.com/farhad-shabani/tendermint-rs"
+rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426"
 default-features = false
 
 [dependencies.tendermint-proto]
-git = "https://github.com/composableFi/tendermint-rs"
-rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8"
+git = "https://github.com/farhad-shabani/tendermint-rs"
+rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426"
 default-features = false
 
 [dev-dependencies]
@@ -67,8 +67,8 @@ tracing-subscriber = { version = "0.3.11", features = ["fmt", "env-filter", "jso
 test-log = { version = "0.2.10", features = ["trace"] }
 modelator = "0.4.2"
 sha2 = { version = "0.10.2" }
-tendermint-rpc = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", features = ["http-client", "websocket-client"] }
-tendermint-testgen = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8" } # Needed for generating (synthetic) light blocks.
+tendermint-rpc = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426", features = ["http-client", "websocket-client"] }
+tendermint-testgen = { git = "https://github.com/farhad-shabani/tendermint-rs", rev= "ab7db0fa89e1634ad9855bc567ba02d9e8916426" } # Needed for generating (synthetic) light blocks.
 tokio = { version = "1.17.0", features = ["full"] }
 serde_json = "1.0.74"
 sha3 = { version = "0.10.1" }


### PR DESCRIPTION
Closes #94

## Description
With regard to issue #93 and as a very first step towards supporting Cosmos and Parachain by each of the Hyperspace and Hermes teams, This PR attempts to scaffold the necessary functionality for relaying some test packets between Cosmos chains through Hyperspace. Basically, it's laying down the foundation to achieve below objectives: 
- Address light client matters
- Have more generic designs to pave the development process for Cosmos<>Parachain 
- Apply lessons learned from Hyperspace and Hermes experience on both ends, including WIP for [Hermes v1.5](https://github.com/informalsystems/hermes/pull/2478)