### PR TITLE
move tendermint deps to workspace level when possible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,8 @@ sp-storage = { git = "https://github.com/paritytech/substrate", branch = "polkad
 sp-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
 sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
 sp-wasm-interface = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
+
+[workspace.dependencies]
+tendermint = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", default-features = false }
+tendermint-proto = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", default-features = false }
+tendermint-light-client-verifier = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", default-features = false }

--- a/contracts/pallet-ibc/Cargo.toml
+++ b/contracts/pallet-ibc/Cargo.toml
@@ -30,8 +30,8 @@ sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-
 cumulus-primitives-core  = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.27" }
 # ibc
 ibc-proto = { path = "../../ibc/proto", default-features = false }
-tendermint = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", optional = true, default-features = false }
-tendermint-proto = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", default-features = false }
+tendermint = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8", optional = true, default-features = false } # cannot be defined as optional in workspace
+tendermint-proto = { workspace = true }
 ics23 = { git = "https://github.com/composablefi/ics23", rev = "b500a5c6068eb53c83c4c6c13bd9d8c25e0bf927", default-features = false }
 grandpa-client-primitives = { package = "grandpa-light-client-primitives", path = "../../algorithms/grandpa/primitives", default-features = false }
 beefy-client-primitives = { package = "beefy-light-client-primitives", path = "../../algorithms/beefy/primitives", default-features = false }
@@ -82,7 +82,7 @@ prost = { version = "0.10" }
 serde = { version = "1.0" }
 simple-iavl = { git = "https://github.com/ComposableFi/simple-avl", rev = "452a1126bfb8a861354b413755ac3c8fda3da4ec" }
 sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-tendermint = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8" }
+tendermint = { workspace = true }
 balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
 pallet-assets = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
 pallet-ibc-ping = { path = "ping", default-features = false }

--- a/contracts/pallet-ibc/rpc/Cargo.toml
+++ b/contracts/pallet-ibc/rpc/Cargo.toml
@@ -27,7 +27,7 @@ sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "pol
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
 sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-tendermint-proto = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8" }
+tendermint-proto = { workspace = true }
 
 [dependencies.ibc]
 path = "../../../ibc/modules"

--- a/hyperspace/core/Cargo.toml
+++ b/hyperspace/core/Cargo.toml
@@ -31,7 +31,7 @@ prometheus = { version = "0.13.0", default-features = false }
 # ibc
 ibc = { path = "../../ibc/modules", features = [] }
 ibc-proto = { path = "../../ibc/proto" }
-tendermint-proto = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8" }
+tendermint-proto = { workspace = true }
 ibc-rpc = { path = "../../contracts/pallet-ibc/rpc" }
 
 ics11-beefy = { path = "../../light-clients/ics11-beefy" }

--- a/hyperspace/metrics/Cargo.toml
+++ b/hyperspace/metrics/Cargo.toml
@@ -15,4 +15,4 @@ anyhow = "1.0.65"
 # ibc
 ibc = { path = "../../ibc/modules" }
 ibc-proto = { path = "../../ibc/proto" }
-tendermint-proto = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8" }
+tendermint-proto = { workspace = true }

--- a/hyperspace/near/Cargo.toml
+++ b/hyperspace/near/Cargo.toml
@@ -34,7 +34,7 @@ sp-keystore = "0.12.0"
 # ibc
 ibc = { path = "../../ibc/modules", features = [] }
 ibc-proto = { path = "../../ibc/proto" }
-tendermint-proto = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8" }
+tendermint-proto = { workspace = true }
 
 # near
 near-crypto = "0.14.0"

--- a/hyperspace/parachain/Cargo.toml
+++ b/hyperspace/parachain/Cargo.toml
@@ -60,7 +60,7 @@ sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "polka
 # composable
 ibc = { path = "../../ibc/modules", features = [] }
 ibc-proto = { path = "../../ibc/proto" }
-tendermint-proto = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8" }
+tendermint-proto = { workspace = true }
 light-client-common = { path = "../../light-clients/common" }
 ibc-rpc = { path = "../../contracts/pallet-ibc/rpc" }
 pallet-ibc = { path = "../../contracts/pallet-ibc" }

--- a/hyperspace/testsuite/Cargo.toml
+++ b/hyperspace/testsuite/Cargo.toml
@@ -18,7 +18,7 @@ json = { version = "1.0.85", package = "serde_json" }
 
 ibc = { path = "../../ibc/modules" }
 ibc-proto = { path = "../../ibc/proto" }
-tendermint-proto = { git = "https://github.com/composableFi/tendermint-rs", rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8" }
+tendermint-proto = { workspace = true }
 
 hyperspace-core = { path = "../core", features = ["testing"] }
 hyperspace-primitives = { path = "../primitives", features = ["testing"] }

--- a/ibc/modules/Cargo.toml
+++ b/ibc/modules/Cargo.toml
@@ -55,14 +55,10 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 sha2 = { version = "0.10.2", optional = true }
 
 [dependencies.tendermint]
-git = "https://github.com/composableFi/tendermint-rs"
-rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8"
-default-features = false
+workspace = true
 
 [dependencies.tendermint-proto]
-git = "https://github.com/composableFi/tendermint-rs"
-rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8"
-default-features = false
+workspace = true
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/ibc/proto/Cargo.toml
+++ b/ibc/proto/Cargo.toml
@@ -31,9 +31,7 @@ schemars    = { version = "0.8", optional = true }
 base64      = { version = "0.13", default-features = false, features = ["alloc"] }
 
 [dependencies.tendermint-proto]
-git = "https://github.com/composableFi/tendermint-rs"
-rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8"
-default-features = false
+workspace = true
 
 [features]
 default     = ["std", "client"]

--- a/light-clients/ics07-tendermint/Cargo.toml
+++ b/light-clients/ics07-tendermint/Cargo.toml
@@ -24,19 +24,13 @@ subtle-encoding = { version = "0.5", default-features = false }
 flex-error = { version = "0.4.4", default-features = false }
 
 [dependencies.tendermint]
-git = "https://github.com/composableFi/tendermint-rs"
-rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8"
-default-features = false
+workspace = true
 
 [dependencies.tendermint-proto]
-git = "https://github.com/composableFi/tendermint-rs"
-rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8"
-default-features = false
+workspace = true
 
 [dependencies.tendermint-light-client-verifier]
-git = "https://github.com/composableFi/tendermint-rs"
-rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8"
-default-features = false
+workspace = true
 
 [dev-dependencies]
 ibc = { path = "../../ibc/modules", features = ["mocks"] }

--- a/light-clients/ics10-grandpa/Cargo.toml
+++ b/light-clients/ics10-grandpa/Cargo.toml
@@ -60,14 +60,11 @@ sp-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch 
 finality-grandpa = { version = "0.16.0", default-features = false }
 
 [dependencies.tendermint]
-git = "https://github.com/composableFi/tendermint-rs"
-rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8"
-default-features = false
+workspace = true
+
 
 [dependencies.tendermint-proto]
-git = "https://github.com/composableFi/tendermint-rs"
-rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8"
-default-features = false
+workspace = true
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/light-clients/ics11-beefy/Cargo.toml
+++ b/light-clients/ics11-beefy/Cargo.toml
@@ -63,14 +63,10 @@ derive_more = { version = "0.99.17", default-features = false, features = ["from
 primitive-types = { version = "0.11.1", default-features = false }
 
 [dependencies.tendermint]
-git = "https://github.com/composableFi/tendermint-rs"
-rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8"
-default-features = false
+workspace = true
 
 [dependencies.tendermint-proto]
-git = "https://github.com/composableFi/tendermint-rs"
-rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8"
-default-features = false
+workspace = true
 
 [dev-dependencies]
 futures = "0.3.24"

--- a/light-clients/ics13-near/Cargo.toml
+++ b/light-clients/ics13-near/Cargo.toml
@@ -51,14 +51,10 @@ sha3 = { version = "0.10.1", optional = true }
 ripemd = { version = "0.1.1", optional = true }
 
 [dependencies.tendermint]
-git = "https://github.com/composableFi/tendermint-rs"
-rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8"
-default-features = false
+workspace = true
 
 [dependencies.tendermint-proto]
-git = "https://github.com/composableFi/tendermint-rs"
-rev = "5a74e0f8da4d3dab83cc04b5f1363b018cf3d9e8"
-default-features = false
+workspace = true
 
 [dev-dependencies]
 ibc = { path = "../../ibc/modules", features = ['mocks'] }


### PR DESCRIPTION
As a request from Informal Systems, tendermint related deps are being moved to the root Cargo toml root.

Alternative solution is to create a meta-crate. 
```
Move tendermint and ibc dependencies to a higher level .toml file. So we can bump these versions more easily.
Currently, tendermint dependencies are spread across multiple places, difficult to track.
Soares: [Workspaces - The Cargo Book](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-workspacedependencies-table) 
Blas: can do.
MZ: Do you want a metacrate, uncertain how it will work.
David: Yes, a metacrate should work. We need tendermint-proto and tendermint-rs.
MZ: Ok, for follow-up discussion, would like to understand all your tm-rs dependencies.
```