### PR TITLE
Leaner (less reliable) relay+para chains setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ result
 **/.asciidoctor
 
 **/.fleet
+
+# lean setup
+lean-setup/

--- a/scripts/build-lean-setup.sh
+++ b/scripts/build-lean-setup.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-parachain-launch generate scripts/parachain-launch/config-lean.yml --output lean-setup/
+parachain-launch generate scripts/parachain-launch/config-lean.yml --output scripts/lean-setup/

--- a/scripts/build-lean-setup.sh
+++ b/scripts/build-lean-setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+parachain-launch generate scripts/parachain-launch/config-lean.yml --output lean-setup/

--- a/scripts/parachain-launch/config-lean.yml
+++ b/scripts/parachain-launch/config-lean.yml
@@ -1,0 +1,75 @@
+# Relaychain Configuration
+relaychain:
+  image: seunlanlege/centauri-polkadot:v0.9.27 # the docker image to use
+  chain: rococo-local # the chain to use
+  runtimeGenesisConfig: # additonal genesis override
+    configuration:
+      config:
+        validation_upgrade_cooldown: 2
+        validation_upgrade_delay: 2
+  env: # environment variables for all relaychain nodes
+    RUST_LOG: parachain::candidate-backing=trace
+  flags: # additional CLI flags for all relaychain nodes
+    - --rpc-methods=unsafe
+    - --beefy
+    - --enable-offchain-indexing=true
+  nodes: # nodes config
+    - name: alice # the node name and session key, this imply `--alice`
+      wsPort: 9944 # default ws port number is `9944 + global_node_index`
+    - name: bob
+    - name: charlie
+    - name: dave
+
+# Parachain Configuration
+parachains:
+  # Config for first parachain
+  - image: seunlanlege/centauri-parachain:v0.9.27
+    chain: # this could be a string like `dev` or a config object
+      base: dev-2000 # the chain to use
+      collators: # override collators
+        - alice # this imply //Alice
+        - bob
+        - charlie
+      sudo: alice # override sudo key to //Alice
+    id: 2000 # override parachain id
+    parachain: true # this is parachain, not parathread
+    flags: # CLI flags for this parachain nodes
+      - --rpc-methods=unsafe
+      - --wasmtime-instantiation-strategy=recreate-instance-copy-on-write
+      - --log=ibc_transfer=trace,pallet_ibc=trace,grandpa-verifier=trace,runtime=trace
+      - --force-authoring
+      - --execution=wasm
+    relaychainFlags: # CLI flags for the relaychain port
+      - --execution=wasm
+#    volumePath: /acala/data # The path to mount volume and base path, default to /data
+    nodes: # nodes config
+      - wsPort: 9188
+        flags: # additional CLI flags for this node
+          - --alice
+        relaychainFlags: # additional CLI flags for relaychain part
+          - --name=relaychain-alice
+      - flags:
+          - --bob
+      - flags:
+          - --charlie
+  # Config for second parachain
+  - image: seunlanlege/centauri-parachain:v0.9.27
+    chain: # this could be a string like `dev` or a config object
+      base: dev-2001 # the chain to use
+      collators: # override collators
+        - alice # this imply //Alice
+      sudo: alice # override sudo key to //Alice
+    id: 2001 # override parachain id
+    parachain: true # this is parachain, not parathread
+    flags: # CLI flags for this parachain nodes
+      - --rpc-methods=unsafe
+      - --wasmtime-instantiation-strategy=recreate-instance-copy-on-write
+      - --log=ibc_transfer=trace,pallet_ibc=trace,grandpa-verifier=trace,runtime=trace
+      - --force-authoring
+      - --execution=wasm
+    relaychainFlags: # CLI flags for the relaychain port
+      - --execution=wasm
+    nodes: # nodes config
+      - wsPort: 9988
+        flags: # additional CLI flags for this node
+          - --alice

--- a/scripts/parachain-launch/config-lean.yml
+++ b/scripts/parachain-launch/config-lean.yml
@@ -38,6 +38,7 @@ parachains:
       - --wasmtime-instantiation-strategy=recreate-instance-copy-on-write
       - --log=ibc_transfer=trace,pallet_ibc=trace,grandpa-verifier=trace,runtime=trace
       - --force-authoring
+      - --enable-offchain-indexing=true
       - --execution=wasm
     relaychainFlags: # CLI flags for the relaychain port
       - --execution=wasm
@@ -66,6 +67,7 @@ parachains:
       - --wasmtime-instantiation-strategy=recreate-instance-copy-on-write
       - --log=ibc_transfer=trace,pallet_ibc=trace,grandpa-verifier=trace,runtime=trace
       - --force-authoring
+      - --enable-offchain-indexing=true
       - --execution=wasm
     relaychainFlags: # CLI flags for the relaychain port
       - --execution=wasm

--- a/scripts/run-lean-setup.sh
+++ b/scripts/run-lean-setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+docker-compose -f lean-setup/ up -d

--- a/scripts/run-lean-setup.sh
+++ b/scripts/run-lean-setup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-docker-compose -f lean-setup/ up -d
+docker-compose -f scripts/lean-setup/docker-compose.yml up -d


### PR DESCRIPTION
Requested by informal, to have something that can run on every machine. Running 3 nodes for the relay chain, and only one collator per parachain.

To test:

```sh
scripts/build-lean-setup.sh
scripts/run-lean-setup.sh
```