### PR TITLE
ci: add sha to docker image being build

### DIFF
--- a/.github/workflows/hyperspace-docker-image.yml
+++ b/.github/workflows/hyperspace-docker-image.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - seun/integration-test # tmp
+      - blas/publish-docker-image-with-sha # tmp
 
 jobs:
   build-and-publish:

--- a/hyperspace/Makefile
+++ b/hyperspace/Makefile
@@ -1,5 +1,7 @@
 module-hyperspace=hyperspace
-composable_centauri_image="composablefi/composable-centauri:latest"
+composable_centauri_image="composablefi/composable-centauri"
+composable_centauri_image_latest="composablefi/composable-centauri:latest"
+composable_centauri_image_with_commit_hash = "${composable_centauri_image}:${GITHUB_SHA}"
 hyperspace_image="composablefi/hyperspace:latest"
 
 .PHONY: run-setup-hyperspace stop-setup-hyperspace build-release-hyperspace tests-hyperspace
@@ -27,7 +29,8 @@ build-docker-image-hyperspace:
 	docker build -f scripts/hyperspace.Dockerfile -t "${hyperspace_image}" .
 
 publish-docker-image-hyperspace:
-	docker push "${hyperspace_image}"
+	docker push "${composable_centauri_image_with_commit_hash}"
+	docker push "${composable_centauri_image_latest}"
 
 tests-hyperspace: 
 	make --ignore-errors stop-setup-hyperspace

--- a/hyperspace/Makefile
+++ b/hyperspace/Makefile
@@ -26,7 +26,8 @@ build-release-hyperspace:
 	cargo b -p $(module-hyperspace) --release
 
 build-docker-image-hyperspace:
-	docker build -f scripts/hyperspace.Dockerfile -t "${hyperspace_image}" .
+	docker build -f scripts/hyperspace.Dockerfile -t "${composable_centauri_image_with_commit_hash}" .
+	docker tag "${composable_centauri_image_with_commit_hash}" "${composable_centauri_image_latest}"
 
 publish-docker-image-hyperspace:
 	docker push "${composable_centauri_image_with_commit_hash}"


### PR DESCRIPTION
One of the requirements of integrating with the `persistent-devnet` is to be able to have a docker image in a docker registry that's linked to a commit. This PR extends the publishing process to add the `sha` hash beside the `latest` tag.
