### PR TITLE
Cosmos support: Refactor `submit` method

### DIFF
--- a/hyperspace/cosmos/src/chain.rs
+++ b/hyperspace/cosmos/src/chain.rs
@@ -13,8 +13,9 @@ use primitives::{Chain, IbcProvider};
 use prost::Message;
 use std::pin::Pin;
 use tendermint_rpc::{
+	event::{Event, EventData},
+	query::{EventType, Query},
 	Client, SubscriptionClient, WebSocketClient,
-	event::Event, query::{EventType, Query}, event::EventData
 };
 
 #[async_trait::async_trait]
@@ -51,8 +52,7 @@ where
 		let stream = subscription.map(|event| {
 			let Event { data, events, query } = event;
 			let header = match data {
-				EventData::NewBlock {block, ..} =>
-					block.unwrap().header,
+				EventData::NewBlock { block, .. } => block.unwrap().header,
 				_ => unreachable!(),
 			};
 			futures::future::ready(Some(FinalityEvent::Tendermint(header)))
@@ -62,65 +62,7 @@ where
 	}
 
 	async fn submit(&self, messages: Vec<Any>) -> Result<Self::TransactionId, Error> {
-		// Create SignerInfo by encoding the keybase
-		let mut pk_buf = Vec::new();
-		Message::encode(&self.keybase.public_key.to_pub().to_bytes(), &mut pk_buf)
-			.map_err(|e| Error::from(e.to_string()))?;
-
-		let pk_type = "/cosmos.crypto.secp256k1.PubKey".to_string();
-		let pk_any = Any { type_url: pk_type, value: pk_buf };
-		let single = Single { mode: 1 };
-		let sum_single = Some(Sum::Single(single));
-		let mode = Some(ModeInfo { sum: sum_single });
-		let signer_info =
-			SignerInfo { public_key: Some(pk_any), mode_info: mode, sequence: 0 as u64 };
-
-		// Create and Encode TxBody
-		let body = TxBody {
-			messages: messages.to_vec(),
-			memo: "".to_string(), //TODO: Check if this is correct
-			timeout_height: 0_u64,
-			extension_options: Vec::<Any>::new(), //TODO: Check if this is correct
-			non_critical_extension_options: Vec::<Any>::new(),
-		};
-		let mut body_bytes = Vec::new();
-		Message::encode(&body, &mut body_bytes).map_err(|e| Error::from(e.to_string()))?;
-
-		// Create and Encode AuthInfo
-		let auth_info = AuthInfo { signer_infos: vec![signer_info], fee: None };
-		let mut auth_info_bytes = Vec::new();
-		Message::encode(&auth_info, &mut auth_info_bytes)
-			.map_err(|e| Error::from(e.to_string()))?;
-
-		// Create and Encode SignDoc
-		let sign_doc = SignDoc {
-			body_bytes: body_bytes.clone(),
-			auth_info_bytes: auth_info_bytes.clone(),
-			chain_id: self.chain_id.to_string(),
-			account_number: self.query_account().await?.account_number,
-		};
-		let mut signdoc_buf = Vec::new();
-		Message::encode(&sign_doc, &mut signdoc_buf).unwrap();
-
-		// Create signature
-		let private_key_bytes = self.keybase.private_key.to_priv().to_bytes();
-		let signing_key = SigningKey::from_bytes(private_key_bytes.as_slice())
-			.map_err(|e| Error::from(e.to_string()))?;
-		let signature: Signature = signing_key.sign(&signdoc_buf);
-		let signature_bytes = signature.as_ref().to_vec();
-
-		// Create and Encode TxRaw
-		let tx_raw = TxRaw { body_bytes, auth_info_bytes, signatures: vec![signature_bytes] };
-		let mut tx_bytes = Vec::new();
-		Message::encode(&tx_raw, &mut tx_bytes).map_err(|e| Error::from(e.to_string()))?;
-
-		// Submit transaction
-		let response = self
-			.rpc_client
-			.broadcast_tx_sync(tx_bytes.into())
-			.await
-			.map_err(|e| Error::from(format!("failed to broadcast transaction {:?}", e)))?;
-
-		Ok(TransactionId { hash: response.hash })
+		let hash = self.submit_call(messages).await?;
+		Ok(Self::TransactionId { hash })
 	}
 }

--- a/hyperspace/cosmos/src/encode.rs
+++ b/hyperspace/cosmos/src/encode.rs
@@ -1,0 +1,85 @@
+use super::{error::Error, key_provider::KeyEntry};
+use ibc::core::ics24_host::identifier::ChainId;
+use ibc_proto::{
+	cosmos::tx::v1beta1::{
+		mode_info::{Single, Sum},
+		AuthInfo, Fee, ModeInfo, SignDoc, SignerInfo, TxBody, TxRaw,
+	},
+	google::protobuf::Any,
+};
+use k256::ecdsa::{signature::Signer as _, Signature, SigningKey};
+use prost::Message;
+
+pub fn encode_key_bytes(key: &KeyEntry) -> Result<Vec<u8>, Error> {
+	let mut pk_buf = Vec::new();
+	Message::encode(&key.public_key.to_pub().to_bytes(), &mut pk_buf)
+		.map_err(|e| Error::from(e.to_string()))?;
+	Ok(pk_buf)
+}
+
+pub fn encode_signer_info(sequence: u64, key_bytes: Vec<u8>) -> Result<SignerInfo, Error> {
+	let pk_any = Any { type_url: "/cosmos.crypto.secp256k1.PubKey".to_string(), value: key_bytes };
+	let single = Single { mode: 1 };
+	let sum_single = Some(Sum::Single(single));
+	let mode = Some(ModeInfo { sum: sum_single });
+	let signer_info = SignerInfo { public_key: Some(pk_any), mode_info: mode, sequence };
+	Ok(signer_info)
+}
+
+pub fn encode_auth_info(signer_info: SignerInfo, fee: Fee) -> Result<(AuthInfo, Vec<u8>), Error> {
+	let auth_info = AuthInfo {
+		signer_infos: vec![signer_info],
+		fee: Some(fee),
+		// tip: None,      // FIXME: This field is required with the newer version of ibc-proto
+	};
+	let mut auth_info_bytes = Vec::new();
+	Message::encode(&auth_info, &mut auth_info_bytes).map_err(|e| Error::from(e.to_string()))?;
+
+	Ok((auth_info, auth_info_bytes))
+}
+
+pub fn encode_sign_doc(
+	key: KeyEntry,
+	body_bytes: Vec<u8>,
+	auth_info_bytes: Vec<u8>,
+	chain_id: ChainId,
+	account_number: u64,
+) -> Result<Vec<u8>, Error> {
+	let sign_doc =
+		SignDoc { body_bytes, auth_info_bytes, chain_id: chain_id.to_string(), account_number };
+	let mut signdoc_buf = Vec::new();
+	prost::Message::encode(&sign_doc, &mut signdoc_buf).unwrap();
+	let private_key_bytes = key.private_key.to_priv().to_bytes();
+	let signing_key = SigningKey::from_bytes(private_key_bytes.as_slice())
+		.map_err(|e| Error::from(e.to_string()))?;
+	let signature: Signature = signing_key.sign(&signdoc_buf);
+	let signature_bytes = signature.as_ref().to_vec();
+
+	Ok(signature_bytes)
+}
+
+pub fn encode_tx_body(messages: Vec<Any>) -> Result<(TxBody, Vec<u8>), Error> {
+	let body = TxBody {
+		messages,
+		memo: "ibc".to_string(),
+		timeout_height: 0_u64,
+		extension_options: Vec::<Any>::default(), /* TODO: Left default for now, but options
+		                                           * could be provided later */
+		non_critical_extension_options: Vec::<Any>::default(),
+	};
+	let mut body_bytes = Vec::new();
+	Message::encode(&body, &mut body_bytes).map_err(|e| Error::from(e.to_string()))?;
+	Ok((body, body_bytes))
+}
+
+pub fn encode_tx(
+	body_bytes: Vec<u8>,
+	auth_info_bytes: Vec<u8>,
+	signature_bytes: Vec<u8>,
+) -> Result<(TxRaw, Vec<u8>), Error> {
+	let tx_raw = TxRaw { body_bytes, auth_info_bytes, signatures: vec![signature_bytes] };
+	let mut tx_bytes = Vec::new();
+	Message::encode(&tx_raw, &mut tx_bytes).map_err(|e| Error::from(e.to_string()))?;
+
+	Ok((tx_raw, tx_bytes))
+}

--- a/hyperspace/cosmos/src/provider.rs
+++ b/hyperspace/cosmos/src/provider.rs
@@ -1,17 +1,29 @@
 use super::{error::Error, CosmosClient};
+use crate::utils::{
+	event_is_type_channel, event_is_type_client, event_is_type_connection,
+	ibc_event_try_from_abci_event,
+};
 use core::time::Duration;
-use futures::{stream::{self, select_all}, Stream, TryFutureExt};
+use futures::{
+	stream::{self, select_all},
+	Stream, TryFutureExt,
+};
 use ibc::{
 	applications::transfer::PrefixedCoin,
 	core::{
-		ics02_client::client_state::ClientType,
-		ics02_client::events::NewBlock,
-		ics23_commitment::commitment:: { CommitmentPrefix, CommitmentProofBytes},
-		ics24_host::identifier::{ChannelId, ClientId, ConnectionId, PortId},
-		ics24_host::path::ClientStatePath
+		ics02_client::{
+			client_state::ClientType, events::NewBlock, msgs::update_client::MsgUpdateAnyClient,
+		},
+		ics23_commitment::commitment::{CommitmentPrefix, CommitmentProofBytes},
+		ics24_host::{
+			identifier::{ChannelId, ClientId, ConnectionId, PortId},
+			path::ClientStatePath,
+		},
 	},
 	events::IbcEvent,
+	keys::STORE_KEY,
 	timestamp::Timestamp,
+	tx_msg::Msg,
 	Height,
 };
 use ibc_proto::{
@@ -22,31 +34,31 @@ use ibc_proto::{
 			QueryPacketAcknowledgementResponse, QueryPacketCommitmentResponse,
 			QueryPacketReceiptResponse,
 		},
-		client::v1::{QueryClientStateResponse, QueryClientStatesRequest, QueryConsensusStateResponse, Height as IBCHeight},
+		client::v1::{
+			Height as IBCHeight, QueryClientStateResponse, QueryClientStatesRequest,
+			QueryConsensusStateResponse,
+		},
 		connection::v1::{IdentifiedConnection, QueryConnectionResponse},
 	},
 };
 use ibc_rpc::PacketInfo;
-use ics07_tendermint::{client_message::Header, events::try_from_tx,
-					   client_message::ClientMessage, merkle::convert_tm_to_ics_merkle_proof
+use ics07_tendermint::{
+	client_message::{ClientMessage, Header},
+	events::try_from_tx,
+	merkle::convert_tm_to_ics_merkle_proof,
 };
 use pallet_ibc::light_clients::{AnyClientMessage, AnyClientState, AnyConsensusState};
-use primitives::{Chain, IbcProvider, UpdateType, mock::LocalClientTypes};
+use primitives::{mock::LocalClientTypes, Chain, IbcProvider, UpdateType};
 use std::{pin::Pin, str::FromStr};
-use tendermint::block::{Height as BlockHeight, Header as BlockHeader};
+use tendermint::block::{Header as BlockHeader, Height as BlockHeight};
 use tendermint_light_client::components::io::{AsyncIo, AtHeight};
 use tendermint_proto::Protobuf;
-use tendermint_rpc::{query::{EventType, Query}, event::{Event, EventData}, Client, Order,
-					 SubscriptionClient, WebSocketClient, abci::Path as TendermintABCIPath,
-					 endpoint::abci_query::AbciQuery, abci::Code
-};
-use ibc::{
-	core::ics02_client::msgs::update_client::MsgUpdateAnyClient, tx_msg::Msg,
-	keys::STORE_KEY,
-};
-use crate::utils::{
-	event_is_type_channel, event_is_type_client,
-	event_is_type_connection, ibc_event_try_from_abci_event,
+use tendermint_rpc::{
+	abci::{Code, Path as TendermintABCIPath},
+	endpoint::abci_query::AbciQuery,
+	event::{Event, EventData},
+	query::{EventType, Query},
+	Client, Order, SubscriptionClient, WebSocketClient,
 };
 
 const KeyClientStorePrefix: &str = "clients";
@@ -65,61 +77,69 @@ pub struct TransactionId<Hash> {
 
 impl<H> CosmosClient<H>
 where
-	H: Clone + Send + Sync + 'static
+	H: Clone + Send + Sync + 'static,
 {
-	async fn msg_update_client_header(&mut self, trusted_height: Height) -> Result<(Header, UpdateType), anyhow::Error> {
+	async fn msg_update_client_header(
+		&mut self,
+		trusted_height: Height,
+	) -> Result<(Header, UpdateType), anyhow::Error> {
 		let latest_light_block = self.light_provider.fetch_light_block(AtHeight::Highest).await?;
 		let height = BlockHeight::try_from(trusted_height.revision_height)?;
-		let trusted_light_block = self.light_provider.fetch_light_block(AtHeight::At(height)).await?;
+		let trusted_light_block =
+			self.light_provider.fetch_light_block(AtHeight::At(height)).await?;
 
-		let update_type = match latest_light_block.validators == latest_light_block.next_validators {
+		let update_type = match latest_light_block.validators == latest_light_block.next_validators
+		{
 			true => UpdateType::Optional,
-			false => UpdateType::Mandatory
+			false => UpdateType::Mandatory,
 		};
 
-		Ok((Header{
-			signed_header: latest_light_block.signed_header,
-			validator_set: latest_light_block.validators,
-			trusted_height,
-			trusted_validator_set: trusted_light_block.validators
-		}, update_type))
+		Ok((
+			Header {
+				signed_header: latest_light_block.signed_header,
+				validator_set: latest_light_block.validators,
+				trusted_height,
+				trusted_validator_set: trusted_light_block.validators,
+			},
+			update_type,
+		))
 	}
 
-	async fn query_tendermint_proof(&self, key: Vec<u8>, height: Height) -> Result<(BytesValue, Proof), Error>{
-		let path = format!("store/{}/key", STORE_KEY).as_str()
-			.parse::<TendermintABCIPath>().map_err(|err| Error::Custom(format!("failed to parse path: {}", err)));
+	async fn query_tendermint_proof(
+		&self,
+		key: Vec<u8>,
+		height: Height,
+	) -> Result<(BytesValue, Proof), Error> {
+		let path = format!("store/{}/key", STORE_KEY)
+			.as_str()
+			.parse::<TendermintABCIPath>()
+			.map_err(|err| Error::Custom(format!("failed to parse path: {}", err)));
 		let height = BlockHeight::try_from(height.revision_height);
-		let query_res =  self.rpc_client.abci_query(
-			path.ok(),
-			key,
-			height.ok(),
-			true,
-		).await?;
+		let query_res = self.rpc_client.abci_query(path.ok(), key, height.ok(), true).await?;
 
 		if !query_res.code.is_ok() {
 			// Fail with response log.
 			// todo()! add response code to error
-			return Err(Error::Custom(format!("failed abci query")));
+			return Err(Error::Custom(format!("failed abci query")))
 		}
 
 		if query_res.proof.is_none() {
 			// Fail due to empty proof
-			return Err(Error::Custom(format!("proof response is empty")));
+			return Err(Error::Custom(format!("proof response is empty")))
 		}
 
 		match query_res {
-			AbciQuery {
-				code: Code::Err(_), ..
-			} => return Err(Error::Custom(format!("failed abci query"))),
-			AbciQuery {
-				proof: None,..
-			} => return Err(Error::Custom(format!("failed abci query"))),
-			_ => ()
+			AbciQuery { code: Code::Err(_), .. } =>
+				return Err(Error::Custom(format!("failed abci query"))),
+			AbciQuery { proof: None, .. } =>
+				return Err(Error::Custom(format!("failed abci query"))),
+			_ => (),
 		};
 
-		let merkle_proof = query_res.proof
-			.map(|p| convert_tm_to_ics_merkle_proof(&p))
-			.ok_or_else(|| Error::Custom("could not convert proof Op to merkle proof".to_string()))?;
+		let merkle_proof =
+			query_res.proof.map(|p| convert_tm_to_ics_merkle_proof(&p)).ok_or_else(|| {
+				Error::Custom("could not convert proof Op to merkle proof".to_string())
+			})?;
 		let proof = CommitmentProofBytes::try_from(merkle_proof)
 			.map_err(|err| Error::Custom(format!("bad client state proof: {}", err)))?;
 		Ok((query_res.value, proof.as_bytes().to_vec()))
@@ -145,8 +165,10 @@ where
 	{
 		let client_id = counterparty.client_id();
 		let latest_cp_height = counterparty.latest_height_and_timestamp().await?.0;
-		let latest_cp_client_state = counterparty.query_client_state(latest_cp_height, client_id).await?;
-		let client_state_response = latest_cp_client_state.client_state
+		let latest_cp_client_state =
+			counterparty.query_client_state(latest_cp_height, client_id).await?;
+		let client_state_response = latest_cp_client_state
+			.client_state
 			.ok_or_else(|| Error::Custom("counterparty returned empty client state".to_string()))?;
 
 		let client_state = AnyClientState::try_from(client_state_response)
@@ -154,20 +176,26 @@ where
 
 		let cs = match client_state {
 			AnyClientState::Tendermint(client_state) => client_state,
-			c => Err(Error::Custom(format!("expected Tendermint::ClientState got {:?}", c)))?
+			c => Err(Error::Custom(format!("expected Tendermint::ClientState got {:?}", c)))?,
 		};
 
 		let latest_cp_client_height = cs.latest_height.revision_height;
 		let latest_height = self.rpc_client.latest_block().await?.block.header.height;
 
 		let mut ibc_events: Vec<IbcEvent> = vec![];
-		for height in latest_cp_client_height+1..latest_height.value()+1 {
+		for height in latest_cp_client_height + 1..latest_height.value() + 1 {
 			// todo()! maybe there's a more efficient way to query for blocks in batches?
-			let block_results = self.rpc_client
-				.block_results(height.into()).await
-				.map_err(|e| Error::from(format!("Failed to query block result for height {:?}: {:?}", height, e)))?;
+			let block_results =
+				self.rpc_client.block_results(height.into()).await.map_err(|e| {
+					Error::from(format!(
+						"Failed to query block result for height {:?}: {:?}",
+						height, e
+					))
+				})?;
 
-			let tx_results = block_results.txs_results.ok_or_else(|| Err(Error::Custom("empty transaction results".to_string())))?;
+			let tx_results = block_results
+				.txs_results
+				.ok_or_else(|| Err(Error::Custom("empty transaction results".to_string())))?;
 			for tx in tx_results.iter() {
 				for event in tx.events {
 					let ibc_event = ibc_event_try_from_abci_event(&event)?;
@@ -180,7 +208,9 @@ where
 		let update_client_header = {
 			let msg = MsgUpdateAnyClient::<LocalClientTypes> {
 				client_id: self.client_id(),
-				client_message: AnyClientMessage::Tendermint(ClientMessage::Header(update_header.0)),
+				client_message: AnyClientMessage::Tendermint(ClientMessage::Header(
+					update_header.0,
+				)),
 				signer: counterparty.account_id(),
 			};
 			let value = msg.encode_vec();
@@ -221,32 +251,31 @@ where
 				let Event { data, events, query } = event;
 				match data {
 					EventData::NewBlock { block, .. }
-					if query == Query::from(EventType::NewBlock).to_string() =>
-						{
-							events.push(NewBlock::new(height).into());
-							// events_with_height.append(&mut extract_block_events(height, &events));
-						},
-					EventData::Tx { tx_result } => {
+						if query == Query::from(EventType::NewBlock).to_string() =>
+					{
+						events.push(NewBlock::new(height).into());
+						// events_with_height.append(&mut extract_block_events(height, &events));
+					},
+					EventData::Tx { tx_result } =>
 						for abci_event in &tx_result.result.events {
 							if let Ok(ibc_event) = ibc_event_try_from_abci_event(abci_event) {
-								if query == Query::eq("message.module", "ibc_client").to_string()
-									&& event_is_type_client(&ibc_event)
+								if query == Query::eq("message.module", "ibc_client").to_string() &&
+									event_is_type_client(&ibc_event)
 								{
 									events.push(ibc_event);
-								} else if query
-									== Query::eq("message.module", "ibc_connection").to_string()
-									&& event_is_type_connection(&ibc_event)
+								} else if query ==
+									Query::eq("message.module", "ibc_connection").to_string() &&
+									event_is_type_connection(&ibc_event)
 								{
 									events.push(ibc_event);
-								} else if query
-									== Query::eq("message.module", "ibc_channel").to_string()
-									&& event_is_type_channel(&ibc_event)
+								} else if query ==
+									Query::eq("message.module", "ibc_channel").to_string() &&
+									event_is_type_channel(&ibc_event)
 								{
 									events.push(ibc_event);
 								}
 							}
-						}
-					},
+						},
 					_ => {},
 				}
 				stream::iter(events).map(Ok)
@@ -271,16 +300,17 @@ where
 		at: Height,
 		client_id: ClientId,
 	) -> Result<QueryClientStateResponse, Self::Error> {
-		let (value, proof) = CosmosClient::query_tendermint_proof(self, ClientStatePath(client_id).into()).await?;
+		let (value, proof) =
+			CosmosClient::query_tendermint_proof(self, ClientStatePath(client_id).into()).await?;
 		let client_state = AnyClientState::decode_vec(&value)?;
 		let any_client_state: Any = client_state.into();
 		Ok(QueryClientStateResponse {
 			proof,
-			proof_height: Some(IBCHeight{
+			proof_height: Some(IBCHeight {
 				revision_height: at.revision_height,
 				revision_number: at.revision_number,
 			}),
-			client_state: Some(any_client_state)
+			client_state: Some(any_client_state),
 		})
 	}
 
@@ -302,30 +332,28 @@ where
 	}
 
 	async fn query_proof(&self, at: Height, keys: Vec<Vec<u8>>) -> Result<Vec<u8>, Self::Error> {
-		let path = format!("store/{}/key", STORE_KEY).as_str()
-			.parse::<TendermintABCIPath>().map_err(|err| Error::Custom(format!("failed to parse path: {}", err)))?;
+		let path = format!("store/{}/key", STORE_KEY)
+			.as_str()
+			.parse::<TendermintABCIPath>()
+			.map_err(|err| Error::Custom(format!("failed to parse path: {}", err)))?;
 		let height = BlockHeight::try_from(at.revision_height);
-		let query_res =  self.rpc_client.abci_query(
-			path.ok(),
-			&*keys[0],
-			height.ok(),
-			true,
-		).await?;
+		let query_res = self.rpc_client.abci_query(path.ok(), &*keys[0], height.ok(), true).await?;
 
 		if !query_res.code.is_ok() {
 			// Fail with response log.
 			// todo()! add response code to error
-			return Err(Error::Custom(format!("failed abci query")));
+			return Err(Error::Custom(format!("failed abci query")))
 		}
 
 		if query_res.proof.is_none() {
 			// Fail due to empty proof
-			return Err(Error::Custom(format!("proof response is empty")));
+			return Err(Error::Custom(format!("proof response is empty")))
 		}
 
-		let merkle_proof = query_res.proof
-			.map(|p| convert_tm_to_ics_merkle_proof(&p))
-			.ok_or_else(|| Error::Custom("could not convert proof Op to merkle proof".to_string()))?;
+		let merkle_proof =
+			query_res.proof.map(|p| convert_tm_to_ics_merkle_proof(&p)).ok_or_else(|| {
+				Error::Custom("could not convert proof Op to merkle proof".to_string())
+			})?;
 		let proof = CommitmentProofBytes::try_from(merkle_proof)
 			.map_err(|err| Error::Custom(format!("bad client state proof: {}", err)))?;
 		Ok(proof.as_bytes().to_vec())

--- a/hyperspace/cosmos/src/tx.rs
+++ b/hyperspace/cosmos/src/tx.rs
@@ -1,0 +1,148 @@
+use super::{
+	encode::{
+		encode_auth_info, encode_key_bytes, encode_sign_doc, encode_signer_info, encode_tx,
+		encode_tx_body,
+	},
+	error::Error,
+	key_provider::KeyEntry,
+};
+use core::time::Duration;
+use ibc::core::ics24_host::identifier::ChainId;
+use ibc_proto::{
+	cosmos::{
+		auth::v1beta1::BaseAccount,
+		tx::v1beta1::{
+			service_client::ServiceClient, Fee, SimulateRequest, SimulateResponse, Tx, TxRaw,
+		},
+	},
+	google::protobuf::Any,
+};
+use prost::Message;
+use tendermint::Hash;
+use tendermint_rpc::{
+	endpoint::tx::Response as TxResponse, query::Query, Client, HttpClient, Order, Url,
+};
+
+pub fn sign_tx(
+	key: KeyEntry,
+	chain_id: ChainId,
+	account_info: &BaseAccount,
+	messages: Vec<Any>,
+	fee: Fee,
+) -> Result<(Tx, TxRaw, Vec<u8>), Error> {
+	let pk_bytes = encode_key_bytes(&key)?;
+	let signer_info = encode_signer_info(account_info.sequence, pk_bytes)?;
+
+	// Create and Encode AuthInfo
+	let (auth_info, auth_info_bytes) = encode_auth_info(signer_info, fee)?;
+
+	// Create and Encode TxBody
+	let (body, body_bytes) = encode_tx_body(messages)?;
+
+	// Create and Encode TxRaw
+	let signature_bytes = encode_sign_doc(
+		key.clone(),
+		body_bytes.clone(),
+		auth_info_bytes.clone(),
+		chain_id.clone(),
+		account_info.account_number,
+	)?;
+
+	// Encode SignDoc and Create Signature
+	let (tx_raw, tx_bytes) = encode_tx(body_bytes, auth_info_bytes, signature_bytes.clone())?;
+
+	let tx = Tx { body: Some(body), auth_info: Some(auth_info), signatures: vec![signature_bytes] };
+
+	Ok((tx, tx_raw, tx_bytes))
+}
+
+pub async fn simulate_tx(
+	grpc_url: Url,
+	tx: Tx,
+	tx_bytes: Vec<u8>,
+) -> Result<SimulateResponse, Error> {
+	#[allow(deprecated)]
+	let req = SimulateRequest {
+		tx: Some(tx), // needed for simulation to go through with Cosmos SDK <  0.43
+		tx_bytes,     // needed for simulation to go through with Cosmos SDk >= 0.43
+	};
+	let mut client = ServiceClient::connect(grpc_url.clone().to_string())
+		.await
+		.map_err(|e| Error::from(e.to_string()))?;
+	let request = tonic::Request::new(req);
+	let response = client
+		.simulate(request)
+		.await
+		.map_err(|e| Error::from(e.to_string()))?
+		.into_inner();
+	Ok(response)
+}
+
+pub async fn broadcast_tx(rpc_client: &HttpClient, tx_bytes: Vec<u8>) -> Result<Hash, Error> {
+	let response = rpc_client
+		.broadcast_tx_sync(tx_bytes)
+		.await
+		.map_err(|e| Error::from(format!("failed to broadcast transaction {:?}", e)))?;
+	Ok(response.hash)
+}
+
+pub async fn confirm_tx(rpc_client: &HttpClient, tx_hash: Hash) -> Result<Hash, Error> {
+	let start_time = tokio::time::Instant::now();
+	let timeout = Duration::from_millis(30000);
+	const WAIT_BACKOFF: Duration = Duration::from_millis(300);
+	let response: TxResponse = loop {
+		let response = rpc_client
+			.tx_search(
+				Query::eq("tx.hash", tx_hash.to_string()),
+				false,
+				1,
+				1, // get only the first Tx matching the query
+				Order::Ascending,
+			)
+			.await
+			.map_err(|e| Error::from(format!("failed to search for transaction {:?}", e)))?;
+		match response.txs.into_iter().next() {
+			None => {
+				let elapsed = start_time.elapsed();
+				if &elapsed > &timeout {
+					return Err(Error::from(format!(
+						"transaction {} not found after {} seconds",
+						tx_hash,
+						elapsed.as_secs()
+					)))
+				} else {
+					tokio::time::sleep(WAIT_BACKOFF).await;
+				}
+			},
+			Some(response) => break response,
+		}
+	};
+
+	let response_code = response.tx_result.code;
+	if response_code.is_err() {
+		return Err(Error::from(format!(
+			"transaction {} failed with code {:?}",
+			tx_hash, response_code
+		)))
+	}
+	Ok(response.hash)
+}
+
+pub fn encoded_tx_metrics(
+	key: KeyEntry,
+	chain_id: ChainId,
+	account_info: &BaseAccount,
+	fee: Fee,
+) -> Result<(usize, usize), Error> {
+	let (_, tx_raw, _) = sign_tx(key, chain_id, account_info, vec![], fee)?;
+
+	let total_len = tx_raw.encoded_len();
+	let body_bytes_len = tx_raw.body_bytes.len();
+	let envelope_len = if body_bytes_len == 0 {
+		total_len
+	} else {
+		total_len - 1 - prost::length_delimiter_len(body_bytes_len) - body_bytes_len
+	};
+
+	Ok((total_len, envelope_len))
+}

--- a/hyperspace/cosmos/src/utils.rs
+++ b/hyperspace/cosmos/src/utils.rs
@@ -2,19 +2,21 @@ use crate::error::Error;
 use core::convert::TryFrom;
 use ibc::events::{Error as IbcEventError, IbcEvent, IbcEventType};
 use std::collections::BTreeMap as HashMap;
-use tendermint_rpc::abci::Event as AbciEvent;
-use tendermint_rpc::{event::Event as RpcEvent, event::EventData as RpcEventData};
+use tendermint_rpc::{
+	abci::Event as AbciEvent,
+	event::{Event as RpcEvent, EventData as RpcEventData},
+};
 
-use ibc::core::ics02_client::{
-	events::{self as ClientEvents, Attributes as ClientAttributes},
-	header::Header,
-};
-use ibc::core::ics03_connection::events::{
-	self as ConnectionEvents, Attributes as ConnectionAttributes,
-};
-use ibc::core::ics04_channel::{
-	events::{self as ChannelEvents, Attributes as ChannelAttributes},
-	packet::Packet,
+use ibc::core::{
+	ics02_client::{
+		events::{self as ClientEvents, Attributes as ClientAttributes},
+		header::Header,
+	},
+	ics03_connection::events::{self as ConnectionEvents, Attributes as ConnectionAttributes},
+	ics04_channel::{
+		events::{self as ChannelEvents, Attributes as ChannelAttributes},
+		packet::Packet,
+	},
 };
 
 fn extract_block_events(block_events: &HashMap<String, Vec<String>>) -> Vec<IbcEvent> {
@@ -303,38 +305,38 @@ pub fn timeout_packet_try_from_abci_event(
 pub fn event_is_type_client(ev: &IbcEvent) -> bool {
 	matches!(
 		ev,
-		IbcEvent::CreateClient(_)
-			| IbcEvent::UpdateClient(_)
-			| IbcEvent::UpgradeClient(_)
-			| IbcEvent::ClientMisbehaviour(_)
+		IbcEvent::CreateClient(_) |
+			IbcEvent::UpdateClient(_) |
+			IbcEvent::UpgradeClient(_) |
+			IbcEvent::ClientMisbehaviour(_)
 	)
 }
 
 pub fn event_is_type_connection(ev: &IbcEvent) -> bool {
 	matches!(
 		ev,
-		IbcEvent::OpenInitConnection(_)
-			| IbcEvent::OpenTryConnection(_)
-			| IbcEvent::OpenAckConnection(_)
-			| IbcEvent::OpenConfirmConnection(_)
+		IbcEvent::OpenInitConnection(_) |
+			IbcEvent::OpenTryConnection(_) |
+			IbcEvent::OpenAckConnection(_) |
+			IbcEvent::OpenConfirmConnection(_)
 	)
 }
 
 pub fn event_is_type_channel(ev: &IbcEvent) -> bool {
 	matches!(
 		ev,
-		IbcEvent::OpenInitChannel(_)
-			| IbcEvent::OpenTryChannel(_)
-			| IbcEvent::OpenAckChannel(_)
-			| IbcEvent::OpenConfirmChannel(_)
-			| IbcEvent::CloseInitChannel(_)
-			| IbcEvent::CloseConfirmChannel(_)
-			| IbcEvent::SendPacket(_)
-			| IbcEvent::ReceivePacket(_)
-			| IbcEvent::WriteAcknowledgement(_)
-			| IbcEvent::AcknowledgePacket(_)
-			| IbcEvent::TimeoutPacket(_)
-			| IbcEvent::TimeoutOnClosePacket(_)
+		IbcEvent::OpenInitChannel(_) |
+			IbcEvent::OpenTryChannel(_) |
+			IbcEvent::OpenAckChannel(_) |
+			IbcEvent::OpenConfirmChannel(_) |
+			IbcEvent::CloseInitChannel(_) |
+			IbcEvent::CloseConfirmChannel(_) |
+			IbcEvent::SendPacket(_) |
+			IbcEvent::ReceivePacket(_) |
+			IbcEvent::WriteAcknowledgement(_) |
+			IbcEvent::AcknowledgePacket(_) |
+			IbcEvent::TimeoutPacket(_) |
+			IbcEvent::TimeoutOnClosePacket(_)
 	)
 }
 
@@ -345,27 +347,24 @@ pub fn client_extract_attributes_from_tx(event: &AbciEvent) -> Result<ClientAttr
 		let key = tag.key.as_ref();
 		let value = tag.value.as_ref();
 		match key {
-			ClientEvents::CLIENT_ID_ATTRIBUTE_KEY => {
+			ClientEvents::CLIENT_ID_ATTRIBUTE_KEY =>
 				attr.client_id = value.parse().map_err(|e| {
 					Error::from(format!("Failed to parse client id from event attribute: {:?}", e))
-				})?
-			},
-			ClientEvents::CLIENT_TYPE_ATTRIBUTE_KEY => {
+				})?,
+			ClientEvents::CLIENT_TYPE_ATTRIBUTE_KEY =>
 				attr.client_type = value.parse().map_err(|e| {
 					Error::from(format!(
 						"Failed to parse client type from event attribute: {:?}",
 						e
 					))
-				})?
-			},
-			ClientEvents::CONSENSUS_HEIGHT_ATTRIBUTE_KEY => {
+				})?,
+			ClientEvents::CONSENSUS_HEIGHT_ATTRIBUTE_KEY =>
 				attr.consensus_height = value.parse().map_err(|e| {
 					Error::from(format!(
 						"Failed to parse consensus height from event attribute: {:?}",
 						e
 					))
-				})?
-			},
+				})?,
 			_ => {},
 		}
 	}
@@ -379,7 +378,7 @@ pub fn extract_header_from_tx(event: &AbciEvent) -> Result<Box<dyn Header>, Erro
 		let value = tag.value.as_ref();
 		if key == "header" {
 			let header_bytes = hex::decode(value).map_err(|e| Error::from(e.to_string()))?;
-			return decode_header(&header_bytes);
+			return decode_header(&header_bytes)
 		}
 	}
 	Err(Error::from("Failed to extract header from event"))
@@ -395,16 +394,14 @@ fn connection_extract_attributes_from_tx(event: &AbciEvent) -> Result<Connection
 			ConnectionEvents::CONN_ID_ATTRIBUTE_KEY => {
 				attr.connection_id = value.parse().ok();
 			},
-			ConnectionEvents::CLIENT_ID_ATTRIBUTE_KEY => {
-				attr.client_id = value.parse().map_err(|e| Error::from(e.to_string()))?
-			},
+			ConnectionEvents::CLIENT_ID_ATTRIBUTE_KEY =>
+				attr.client_id = value.parse().map_err(|e| Error::from(e.to_string()))?,
 			ConnectionEvents::COUNTERPARTY_CONN_ID_ATTRIBUTE_KEY => {
 				attr.counterparty_connection_id = value.parse().ok();
 			},
-			ConnectionEvents::COUNTERPARTY_CLIENT_ID_ATTRIBUTE_KEY => {
+			ConnectionEvents::COUNTERPARTY_CLIENT_ID_ATTRIBUTE_KEY =>
 				attr.counterparty_client_id =
-					value.parse().map_err(|e| Error::from(e.to_string()))?
-			},
+					value.parse().map_err(|e| Error::from(e.to_string()))?,
 			_ => {},
 		}
 	}
@@ -419,18 +416,15 @@ fn channel_extract_attributes_from_tx(event: &AbciEvent) -> Result<ChannelAttrib
 		let key = tag.key.as_ref();
 		let value = tag.value.as_ref();
 		match key {
-			ChannelEvents::PORT_ID_ATTRIBUTE_KEY => {
-				attr.port_id = value.parse().map_err(|e| Error::from(e.to_string()))?
-			},
+			ChannelEvents::PORT_ID_ATTRIBUTE_KEY =>
+				attr.port_id = value.parse().map_err(|e| Error::from(e.to_string()))?,
 			ChannelEvents::CHANNEL_ID_ATTRIBUTE_KEY => {
 				attr.channel_id = value.parse().ok();
 			},
-			ChannelEvents::CONNECTION_ID_ATTRIBUTE_KEY => {
-				attr.connection_id = value.parse().map_err(|e| Error::from(e.to_string()))?
-			},
-			ChannelEvents::COUNTERPARTY_PORT_ID_ATTRIBUTE_KEY => {
-				attr.counterparty_port_id = value.parse().map_err(|e| Error::from(e.to_string()))?
-			},
+			ChannelEvents::CONNECTION_ID_ATTRIBUTE_KEY =>
+				attr.connection_id = value.parse().map_err(|e| Error::from(e.to_string()))?,
+			ChannelEvents::COUNTERPARTY_PORT_ID_ATTRIBUTE_KEY =>
+				attr.counterparty_port_id = value.parse().map_err(|e| Error::from(e.to_string()))?,
 			ChannelEvents::COUNTERPARTY_CHANNEL_ID_ATTRIBUTE_KEY => {
 				attr.counterparty_channel_id = value.parse().ok();
 			},
@@ -448,26 +442,20 @@ fn extract_packet_and_write_ack_from_tx(event: &AbciEvent) -> Result<(Packet, Ve
 		let key = tag.key.as_ref();
 		let value = tag.value.as_ref();
 		match key {
-			ChannelEvents::PKT_SRC_PORT_ATTRIBUTE_KEY => {
-				packet.source_port = value.parse().map_err(|e| Error::from(e.to_string()))?
-			},
-			ChannelEvents::PKT_SRC_CHANNEL_ATTRIBUTE_KEY => {
-				packet.source_channel = value.parse().map_err(|e| Error::from(e.to_string()))?
-			},
-			ChannelEvents::PKT_DST_PORT_ATTRIBUTE_KEY => {
-				packet.destination_port = value.parse().map_err(|e| Error::from(e.to_string()))?
-			},
-			ChannelEvents::PKT_DST_CHANNEL_ATTRIBUTE_KEY => {
+			ChannelEvents::PKT_SRC_PORT_ATTRIBUTE_KEY =>
+				packet.source_port = value.parse().map_err(|e| Error::from(e.to_string()))?,
+			ChannelEvents::PKT_SRC_CHANNEL_ATTRIBUTE_KEY =>
+				packet.source_channel = value.parse().map_err(|e| Error::from(e.to_string()))?,
+			ChannelEvents::PKT_DST_PORT_ATTRIBUTE_KEY =>
+				packet.destination_port = value.parse().map_err(|e| Error::from(e.to_string()))?,
+			ChannelEvents::PKT_DST_CHANNEL_ATTRIBUTE_KEY =>
 				packet.destination_channel =
-					value.parse().map_err(|e| Error::from(e.to_string()))?
-			},
-			ChannelEvents::PKT_SEQ_ATTRIBUTE_KEY => {
+					value.parse().map_err(|e| Error::from(e.to_string()))?,
+			ChannelEvents::PKT_SEQ_ATTRIBUTE_KEY =>
 				packet.sequence =
-					value.parse::<u64>().map_err(|e| Error::from(e.to_string()))?.into()
-			},
-			ChannelEvents::PKT_TIMEOUT_HEIGHT_ATTRIBUTE_KEY => {
-				packet.timeout_height = value.parse().map_err(|e| Error::from(e.to_string()))?
-			},
+					value.parse::<u64>().map_err(|e| Error::from(e.to_string()))?.into(),
+			ChannelEvents::PKT_TIMEOUT_HEIGHT_ATTRIBUTE_KEY =>
+				packet.timeout_height = value.parse().map_err(|e| Error::from(e.to_string()))?,
 			ChannelEvents::PKT_TIMEOUT_TIMESTAMP_ATTRIBUTE_KEY => {
 				packet.timeout_timestamp = value.parse().unwrap();
 			},


### PR DESCRIPTION
In continuation of #93

## Description
This PR refactors `submit` call provided at #114 and places encoding and transaction operations inside separate modules of `tx.rs` and `encode.rs`