### PR TITLE
Remove child trie iteration 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3903,6 +3903,7 @@ dependencies = [
  "primitive-types",
  "prost 0.11.0",
  "safe-regex",
+ "scale-info",
  "serde",
  "serde_derive",
  "serde_json",

--- a/contracts/pallet-ibc/src/ics23/consensus_states.rs
+++ b/contracts/pallet-ibc/src/ics23/consensus_states.rs
@@ -13,14 +13,13 @@
 // limitations under the License.
 
 use crate::{format, Config};
-use alloc::string::String;
-use frame_support::storage::{child, child::ChildInfo, ChildTriePrefixIterator};
+use frame_support::storage::{child, child::ChildInfo};
 use ibc::{
 	core::ics24_host::{identifier::ClientId, path::ClientConsensusStatePath},
 	Height,
 };
 use ibc_primitives::apply_prefix;
-use sp_std::{marker::PhantomData, prelude::*, str::FromStr};
+use sp_std::{marker::PhantomData, prelude::*};
 
 /// client_id, height => consensus_state
 /// trie key path: "clients/{client_id}/consensusStates/{height}"
@@ -49,45 +48,4 @@ impl<T: Config> ConsensusStates<T> {
 		let key = apply_prefix(T::PALLET_PREFIX, vec![path]);
 		child::put(&ChildInfo::new_default(T::PALLET_PREFIX), &key, &consensus_state)
 	}
-
-	// WARNING: too expensive to be called from an on-chain context, only here for rpc layer.
-	pub fn iter_key_prefix(client_id: &ClientId) -> impl Iterator<Item = (Height, Vec<u8>)> {
-		let prefix_path = format!("clients/{}/consensusStates/", client_id);
-		let key = apply_prefix(T::PALLET_PREFIX, vec![prefix_path]);
-		ChildTriePrefixIterator::with_prefix(&ChildInfo::new_default(T::PALLET_PREFIX), &key)
-			.filter_map(|(key, value)| {
-				let height = Height::from_str(&String::from_utf8(key).ok()?).ok()?;
-				Some((height, value))
-			})
-	}
 }
-
-// #[cfg(test)]
-// mod tests {
-// 	use super::ConsensusStates;
-// 	use crate::mock::*;
-// 	use ibc::core::{ics02_client::height::Height, ics24_host::identifier::ClientId};
-// 	use sp_io::TestExternalities;
-
-// 	#[test]
-// 	fn test_child_trie_prefix_iterator() {
-// 		TestExternalities::default().execute_with(|| {
-// 			let client_id = ClientId::new("11-beefy", 1).unwrap();
-
-// 			for height in 0..100u64 {
-// 				let height = Height { revision_height: height, revision_number: 2000 };
-// 				ConsensusStates::<Test>::insert(client_id.clone(), height, [255u8; 32].to_vec());
-// 			}
-
-// 			let item = ConsensusStates::<Test>::get(
-// 				client_id.clone(),
-// 				Height { revision_height: 99, revision_number: 2000 },
-// 			);
-// 			println!("item: {:#?}", item);
-
-// 			let keys = ConsensusStates::<Test>::iter_key_prefix(&client_id).collect::<Vec<_>>();
-
-// 			println!("iter_key_prefix: {:#?}", keys)
-// 		});
-// 	}
-// }

--- a/contracts/pallet-ibc/src/lib.rs
+++ b/contracts/pallet-ibc/src/lib.rs
@@ -348,7 +348,7 @@ pub mod pallet {
 		_,
 		Blake2_128Concat,
 		Vec<u8>,
-		BoundedBTreeSet<(u64, u64), frame_support::traits::ConstU32<256>>,
+		BoundedBTreeSet<Height, frame_support::traits::ConstU32<256>>,
 		ValueQuery,
 	>;
 

--- a/contracts/pallet-ibc/src/lib.rs
+++ b/contracts/pallet-ibc/src/lib.rs
@@ -190,10 +190,7 @@ pub mod pallet {
 		IbcHandler,
 	};
 	use light_clients::AnyClientState;
-	use sp_runtime::{
-		traits::{IdentifyAccount, Saturating},
-		AccountId32,
-	};
+	use sp_runtime::{traits::{IdentifyAccount, Saturating}, AccountId32, BoundedBTreeSet};
 	#[cfg(feature = "std")]
 	use sp_runtime::{Deserialize, Serialize};
 	use sp_std::collections::btree_set::BTreeSet;
@@ -339,6 +336,11 @@ pub mod pallet {
 	#[allow(clippy::disallowed_types)]
 	/// Active Escrow addresses
 	pub type EscrowAddresses<T: Config> = StorageValue<_, BTreeSet<T::AccountId>, ValueQuery>;
+
+	#[pallet::storage]
+	#[allow(clippy::disallowed_types)]
+	/// Consensus heights
+	pub type ConsensusHeights<T: Config> = StorageMap<_, Blake2_128Concat, Vec<u8>, BoundedBTreeSet<(u64, u64), frame_support::traits::ConstU32<256>>, ValueQuery>;
 
 	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 	pub struct AssetConfig<AssetId> {

--- a/contracts/pallet-ibc/src/lib.rs
+++ b/contracts/pallet-ibc/src/lib.rs
@@ -190,7 +190,10 @@ pub mod pallet {
 		IbcHandler,
 	};
 	use light_clients::AnyClientState;
-	use sp_runtime::{traits::{IdentifyAccount, Saturating}, AccountId32, BoundedBTreeSet};
+	use sp_runtime::{
+		traits::{IdentifyAccount, Saturating},
+		AccountId32, BoundedBTreeSet,
+	};
 	#[cfg(feature = "std")]
 	use sp_runtime::{Deserialize, Serialize};
 	use sp_std::collections::btree_set::BTreeSet;
@@ -340,7 +343,14 @@ pub mod pallet {
 	#[pallet::storage]
 	#[allow(clippy::disallowed_types)]
 	/// Consensus heights
-	pub type ConsensusHeights<T: Config> = StorageMap<_, Blake2_128Concat, Vec<u8>, BoundedBTreeSet<(u64, u64), frame_support::traits::ConstU32<256>>, ValueQuery>;
+	/// Stored as a tuple of (revision_number, revision_height)
+	pub type ConsensusHeights<T: Config> = StorageMap<
+		_,
+		Blake2_128Concat,
+		Vec<u8>,
+		BoundedBTreeSet<(u64, u64), frame_support::traits::ConstU32<256>>,
+		ValueQuery,
+	>;
 
 	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 	pub struct AssetConfig<AssetId> {

--- a/ibc/modules/Cargo.toml
+++ b/ibc/modules/Cargo.toml
@@ -26,6 +26,7 @@ std = [
     "sp-core/std",
     "sp-std/std",
     "codec/std",
+    "scale-info/std"
 ]
 clock = ["tendermint/clock", "time/std"]
 
@@ -55,6 +56,7 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 sha2 = { version = "0.10.2", optional = true }
 tendermint = { git = "https://github.com/composableFi/tendermint-rs", rev = "2c513dcaf2385d5b5f55e129a5ed11cc8d8ad5d0", default-features = false }
 tendermint-proto = { git = "https://github.com/composableFi/tendermint-rs", rev = "2c513dcaf2385d5b5f55e129a5ed11cc8d8ad5d0", default-features = false }
+scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/ibc/modules/src/core/ics02_client/height.rs
+++ b/ibc/modules/src/core/ics02_client/height.rs
@@ -25,7 +25,18 @@ use ibc_proto::ibc::core::client::v1::Height as RawHeight;
 
 use crate::core::ics02_client::error::Error;
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(
+	Copy,
+	Clone,
+	PartialEq,
+	Eq,
+	Hash,
+	Serialize,
+	Deserialize,
+	codec::Encode,
+	codec::Decode,
+	scale_info::TypeInfo,
+)]
 pub struct Height {
 	/// Previously known as "epoch"
 	pub revision_number: u64,


### PR DESCRIPTION
This change stores 256 of the most recent consensus heights for a specific light client in a bounded btree set, this is allows us to make some preliminary checks when accepting light client updates for block heights that are less than the latest consensus height.

