### PR TITLE
Fix ss58 hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4011,6 +4011,7 @@ name = "ibc-primitives"
 version = "0.1.0"
 dependencies = [
  "base58",
+ "blake2",
  "frame-support",
  "hex",
  "ibc",

--- a/contracts/pallet-ibc/primitives/Cargo.toml
+++ b/contracts/pallet-ibc/primitives/Cargo.toml
@@ -16,6 +16,7 @@ sha2 = { version = "0.10.2", default-features = false }
 sha3 = { version = "0.10.1", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 base58 = "0.2.0"
+blake2 = { version = "0.10", default-features = false }
 
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }

--- a/contracts/pallet-ibc/primitives/src/runtime_interface.rs
+++ b/contracts/pallet-ibc/primitives/src/runtime_interface.rs
@@ -81,10 +81,10 @@ pub fn ss58_to_account_id_32(raw_str: &str) -> Result<[u8; 32], SS58CodecError> 
 		.map_err(|_| SS58CodecError::InvalidString)
 }
 
-pub fn account_id_to_ss58(bytes: [u8; 32], version: u16) -> Result<Vec<u8>, SS58CodecError> {
+pub fn account_id_to_ss58(bytes: [u8; 32], version: u16) -> Vec<u8> {
 	let account_id = AccountId32::new(bytes);
 	let encoded = to_ss58check_with_version(account_id, version);
-	Ok(encoded.as_bytes().to_vec())
+	encoded.as_bytes().to_vec()
 }
 
 // lifted directly from sp-core
@@ -181,6 +181,15 @@ mod tests {
 		ecdsa::{Pair, Public},
 		Pair as _,
 	};
+
+	#[test]
+	fn ss58_test() {
+		// make sure that decode(encode(address)) = address
+		let alice = "5yNZjX24n2eg7W6EVamaTXNQbWCwchhThEaSWB7V3GRjtHeL";
+		let account_id = ss58_to_account_id_32(alice).unwrap();
+		let ss58_account = account_id_to_ss58(account_id.into(), 49);
+		assert_eq!(alice, String::from_utf8(ss58_account).unwrap());
+	}
 
 	#[test]
 	fn ss58check_format_check_works() {

--- a/contracts/pallet-ibc/primitives/src/runtime_interface.rs
+++ b/contracts/pallet-ibc/primitives/src/runtime_interface.rs
@@ -165,9 +165,12 @@ where
 
 /// uses host functions for hashing
 fn ss58hash(data: &[u8]) -> Vec<u8> {
-	let mut pre_image = b"SS58PRE".to_vec();
-	pre_image.extend(data);
-	sp_io::hashing::blake2_256(&pre_image).to_vec()
+	use blake2::{Blake2b512, Digest};
+
+	let mut ctx = Blake2b512::new();
+	ctx.update(b"SS58PRE");
+	ctx.update(data);
+	ctx.finalize().to_vec()
 }
 
 #[cfg(test)]

--- a/contracts/pallet-ibc/src/impls.rs
+++ b/contracts/pallet-ibc/src/impls.rs
@@ -62,14 +62,13 @@ use ibc::{
 };
 use ibc_primitives::{
 	apply_prefix, channel_id_from_bytes, client_id_from_bytes, connection_id_from_bytes,
-	get_channel_escrow_address, port_id_from_bytes, runtime_interface,
-	runtime_interface::SS58CodecError, ConnectionHandshake, Error as IbcHandlerError,
-	HandlerMessage, IbcHandler, IdentifiedChannel, IdentifiedClientState, IdentifiedConnection,
-	PacketInfo, PacketState, QueryChannelResponse, QueryChannelsResponse, QueryClientStateResponse,
-	QueryConnectionResponse, QueryConnectionsResponse, QueryConsensusStateResponse,
-	QueryNextSequenceReceiveResponse, QueryPacketAcknowledgementResponse,
-	QueryPacketAcknowledgementsResponse, QueryPacketCommitmentResponse,
-	QueryPacketCommitmentsResponse, QueryPacketReceiptResponse,
+	get_channel_escrow_address, port_id_from_bytes, runtime_interface, ConnectionHandshake,
+	Error as IbcHandlerError, HandlerMessage, IbcHandler, IdentifiedChannel, IdentifiedClientState,
+	IdentifiedConnection, PacketInfo, PacketState, QueryChannelResponse, QueryChannelsResponse,
+	QueryClientStateResponse, QueryConnectionResponse, QueryConnectionsResponse,
+	QueryConsensusStateResponse, QueryNextSequenceReceiveResponse,
+	QueryPacketAcknowledgementResponse, QueryPacketAcknowledgementsResponse,
+	QueryPacketCommitmentResponse, QueryPacketCommitmentsResponse, QueryPacketReceiptResponse,
 };
 use scale_info::prelude::string::ToString;
 use sp_core::{crypto::AccountId32, offchain::StorageKind};
@@ -1031,9 +1030,8 @@ where
 		let from = runtime_interface::account_id_to_ss58(
 			account_id_32.into(),
 			<T as frame_system::Config>::SS58Prefix::get(),
-		)
-		.and_then(|val| String::from_utf8(val).map_err(|_| SS58CodecError::InvalidAccountId))
-		.map_err(|_| IbcHandlerError::SendTransferError {
+		);
+		let from = String::from_utf8(from).map_err(|_| IbcHandlerError::SendTransferError {
 			msg: Some("Account Id conversion failed".to_string()),
 		})?;
 		let (latest_height, latest_timestamp) =

--- a/contracts/pallet-ibc/src/tests.rs
+++ b/contracts/pallet-ibc/src/tests.rs
@@ -220,8 +220,7 @@ fn send_transfer() {
 	let mut ext = new_test_ext();
 	ext.execute_with(|| {
 		let pair = sp_core::sr25519::Pair::from_seed(b"12345678901234567890123456789012");
-		let raw_user =
-			ibc_primitives::runtime_interface::account_id_to_ss58(pair.public().0, 49).unwrap();
+		let raw_user = ibc_primitives::runtime_interface::account_id_to_ss58(pair.public().0, 49);
 		let ss58_address = String::from_utf8(raw_user).unwrap();
 		setup_client_and_consensus_state(PortId::transfer());
 		let balance = 100000 * MILLIS;
@@ -277,7 +276,7 @@ fn on_deliver_ics20_recv_packet() {
 		// Create  a new account
 		let pair = sp_core::sr25519::Pair::from_seed(b"12345678901234567890123456789012");
 		let ss58_address_bytes =
-			ibc_primitives::runtime_interface::account_id_to_ss58(pair.public().0, 49).unwrap();
+			ibc_primitives::runtime_interface::account_id_to_ss58(pair.public().0, 49);
 		let ss58_address = String::from_utf8(ss58_address_bytes).unwrap();
 		frame_system::Pallet::<Test>::set_block_number(1u32);
 		let asset_id =


### PR DESCRIPTION
1. We should be using `blake2 512` instead of `blake2 256`. The implementation is the same as substrate's. See: https://docs.rs/sp-core/latest/src/sp_core/crypto.rs.html#367
2. I also make the account id to ss58 conversion infallible. #171 

Signed-off-by: aeryz <abdullaheryz@protonmail.com>