### PR TITLE
Remove workspace.dependencies #862j398gn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,8 +72,3 @@ sp-storage = { git = "https://github.com/paritytech/substrate", branch = "polkad
 sp-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.30" }
 sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.30" }
 sp-wasm-interface = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.30" }
-
-[workspace.dependencies]
-tendermint = { git = "https://github.com/composableFi/tendermint-rs", rev = "2c513dcaf2385d5b5f55e129a5ed11cc8d8ad5d0", default-features = false }
-tendermint-proto = { git = "https://github.com/composableFi/tendermint-rs", rev = "2c513dcaf2385d5b5f55e129a5ed11cc8d8ad5d0", default-features = false }
-tendermint-light-client-verifier = { git = "https://github.com/composableFi/tendermint-rs", rev = "2c513dcaf2385d5b5f55e129a5ed11cc8d8ad5d0", default-features = false }


### PR DESCRIPTION
We have to remove `workspace.dependencies` section to nixify `hyperpace` in `composable` repo.