### PR TITLE
update image with polkadot v0.9.33

### DIFF
--- a/scripts/parachain-launch/config.yml
+++ b/scripts/parachain-launch/config.yml
@@ -1,6 +1,6 @@
 # Relaychain Configuration
 relaychain:
-  image: seunlanlege/centauri-polkadot:v0.9.27 # the docker image to use
+  image: parity/polkadot:v0.9.33 # the docker image to use
   chain: rococo-local # the chain to use
   runtimeGenesisConfig: # additonal genesis override
     configuration:


### PR DESCRIPTION
fix the wrong image for the generated file `relaychain.Dockerfile`:
`seunlanlege/centauri-polkadot:v0.9.27` -> `parity/polkadot:v0.9.33` 