### PR TITLE
Implement `check_substitute_and_update_state` in cw-grandpa contract

### DIFF
--- a/contracts/pallet-ibc/src/client.rs
+++ b/contracts/pallet-ibc/src/client.rs
@@ -434,14 +434,14 @@ where
 		let unpacked = client_state.unpack_recursive();
 		let (relay_chain, para_id, latest_para_height) = match unpacked {
 			AnyClientState::Beefy(client_state) => {
-				if client_state.is_frozen() {
+				if client_state.frozen_height.is_some() {
 					Err(ICS02Error::implementation_specific(format!("client state is frozen")))?
 				}
 
 				(client_state.relay_chain, client_state.para_id, client_state.latest_para_height)
 			},
 			AnyClientState::Grandpa(client_state) => {
-				if client_state.is_frozen() {
+				if client_state.frozen_height.is_some() {
 					Err(ICS02Error::implementation_specific(format!("client state is frozen")))?
 				}
 

--- a/ibc/modules/src/core/ics02_client/client_def.rs
+++ b/ibc/modules/src/core/ics02_client/client_def.rs
@@ -97,6 +97,15 @@ pub trait ClientDef: Clone {
 		proof_upgrade_consensus_state: Vec<u8>,
 	) -> Result<(Self::ClientState, ConsensusUpdateResult<Ctx>), Error>;
 
+	fn check_substitute_and_update_state<Ctx: ReaderContext>(
+		&self,
+		ctx: &Ctx,
+		subject_client_id: ClientId,
+		substitute_client_id: ClientId,
+		old_client_state: Self::ClientState,
+		substitute_client_state: Self::ClientState,
+	) -> Result<(Self::ClientState, ConsensusUpdateResult<Ctx>), Error>;
+
 	/// Verification functions as specified in:
 	/// <https://github.com/cosmos/ibc/tree/master/spec/core/ics-002-client-semantics>
 	///
@@ -228,4 +237,6 @@ pub trait ClientDef: Clone {
 		channel_id: &ChannelId,
 		sequence: Sequence,
 	) -> Result<(), Error>;
+
+	// fn status(&self)
 }

--- a/ibc/modules/src/core/ics02_client/client_def.rs
+++ b/ibc/modules/src/core/ics02_client/client_def.rs
@@ -97,6 +97,9 @@ pub trait ClientDef: Clone {
 		proof_upgrade_consensus_state: Vec<u8>,
 	) -> Result<(Self::ClientState, ConsensusUpdateResult<Ctx>), Error>;
 
+	/// Must verify that the provided substitute may be used to update the subject client.
+	/// The light client must set the updated client and consensus states within the client store
+	/// for the subject client.
 	fn check_substitute_and_update_state<Ctx: ReaderContext>(
 		&self,
 		ctx: &Ctx,

--- a/ibc/modules/src/core/ics02_client/handler/update_client.rs
+++ b/ibc/modules/src/core/ics02_client/handler/update_client.rs
@@ -67,7 +67,7 @@ where
 
 	let client_def = client_state.client_def();
 
-	if client_state.is_frozen() {
+	if client_state.is_frozen(ctx, &client_id) {
 		return Err(Error::client_frozen(client_id))
 	}
 

--- a/ibc/modules/src/core/ics02_client/handler/upgrade_client.rs
+++ b/ibc/modules/src/core/ics02_client/handler/upgrade_client.rs
@@ -56,7 +56,7 @@ where
 	// Read client state from the host chain store.
 	let client_state = ctx.client_state(&client_id)?;
 
-	if client_state.is_frozen() {
+	if client_state.is_frozen(ctx, &client_id) {
 		return Err(Error::client_frozen(client_id))
 	}
 

--- a/ibc/modules/src/core/ics04_channel/handler/send_packet.rs
+++ b/ibc/modules/src/core/ics04_channel/handler/send_packet.rs
@@ -75,7 +75,7 @@ pub fn send_packet<Ctx: ReaderContext>(
 		.map_err(|e| Error::implementation_specific(e.to_string()))?;
 
 	// prevent accidental sends with clients that cannot be updated
-	if client_state.is_frozen() {
+	if client_state.is_frozen(ctx, &client_id) {
 		return Err(Error::frozen_client(connection_end.client_id().clone()))
 	}
 

--- a/ibc/modules/src/core/ics04_channel/handler/verify.rs
+++ b/ibc/modules/src/core/ics04_channel/handler/verify.rs
@@ -50,7 +50,7 @@ where
 	let client_state = ctx.client_state(&client_id).map_err(Error::ics02_client)?;
 
 	// The client must not be frozen.
-	if client_state.is_frozen() {
+	if client_state.is_frozen(ctx, &client_id) {
 		return Err(Error::frozen_client(client_id))
 	}
 
@@ -93,7 +93,7 @@ pub fn verify_packet_recv_proofs<Ctx: ReaderContext>(
 	let client_state = ctx.client_state(client_id).map_err(Error::ics02_client)?;
 
 	// The client must not be frozen.
-	if client_state.is_frozen() {
+	if client_state.is_frozen(ctx, client_id) {
 		return Err(Error::frozen_client(client_id.clone()))
 	}
 
@@ -139,7 +139,7 @@ pub fn verify_packet_acknowledgement_proofs<Ctx: ReaderContext>(
 	let client_state = ctx.client_state(client_id).map_err(Error::ics02_client)?;
 
 	// The client must not be frozen.
-	if client_state.is_frozen() {
+	if client_state.is_frozen(ctx, client_id) {
 		return Err(Error::frozen_client(client_id.clone()))
 	}
 
@@ -187,7 +187,7 @@ where
 	let client_state = ctx.client_state(client_id).map_err(Error::ics02_client)?;
 
 	// The client must not be frozen.
-	if client_state.is_frozen() {
+	if client_state.is_frozen(ctx, client_id) {
 		return Err(Error::frozen_client(client_id.clone()))
 	}
 
@@ -230,7 +230,7 @@ where
 	let client_state = ctx.client_state(client_id).map_err(Error::ics02_client)?;
 
 	// The client must not be frozen.
-	if client_state.is_frozen() {
+	if client_state.is_frozen(ctx, client_id) {
 		return Err(Error::frozen_client(client_id.clone()))
 	}
 

--- a/ibc/modules/src/mock/client_state.rs
+++ b/ibc/modules/src/mock/client_state.rs
@@ -140,10 +140,6 @@ impl ClientState for MockClientState {
 		self.latest_height()
 	}
 
-	fn frozen_height(&self) -> Option<Height> {
-		self.frozen_height()
-	}
-
 	fn upgrade(self, _upgrade_height: Height, _upgrade_options: (), _chain_id: ChainId) -> Self {
 		self.upgrade(_upgrade_height, _upgrade_options, _chain_id)
 	}

--- a/ibc/modules/src/test_utils.rs
+++ b/ibc/modules/src/test_utils.rs
@@ -668,7 +668,11 @@ impl<C: HostBlockType> ClientKeeper for DummyTransferModule<C> {
 		Ok(())
 	}
 
-	fn validate_self_client(&self, _client_state: &Self::AnyClientState) -> Result<(), Ics02Error> {
+	fn validate_self_client(
+		&self,
+		_client_id: ClientId,
+		_client_state: &Self::AnyClientState,
+	) -> Result<(), Ics02Error> {
 		Ok(())
 	}
 }

--- a/light-clients/ics07-tendermint/src/client_def.rs
+++ b/light-clients/ics07-tendermint/src/client_def.rs
@@ -331,7 +331,19 @@ where
 		_proof_upgrade_client: Vec<u8>,
 		_proof_upgrade_consensus_state: Vec<u8>,
 	) -> Result<(Self::ClientState, ConsensusUpdateResult<Ctx>), Ics02Error> {
-		// TODO:
+		// TODO: tendermint verify_upgrade_and_update_state
+		Err(Ics02Error::implementation_specific("Not implemented".to_string()))
+	}
+
+	fn check_substitute_and_update_state<Ctx: ReaderContext>(
+		&self,
+		ctx: &Ctx,
+		subject_client_id: ClientId,
+		substitute_client_id: ClientId,
+		old_client_state: Self::ClientState,
+		substitute_client_state: Self::ClientState,
+	) -> Result<(Self::ClientState, ConsensusUpdateResult<Ctx>), Ics02Error> {
+		// TODO: tendermint check_substitute_and_update_state
 		Err(Ics02Error::implementation_specific("Not implemented".to_string()))
 	}
 

--- a/light-clients/ics08-wasm/src/client_def.rs
+++ b/light-clients/ics08-wasm/src/client_def.rs
@@ -159,6 +159,32 @@ where
 			})
 	}
 
+	fn check_substitute_and_update_state<Ctx: ReaderContext>(
+		&self,
+		ctx: &Ctx,
+		subject_client_id: ClientId,
+		substitute_client_id: ClientId,
+		old_client_state: Self::ClientState,
+		substitute_client_state: Self::ClientState,
+	) -> Result<(Self::ClientState, ConsensusUpdateResult<Ctx>), Error> {
+		let (inner_client_state, inner_consensus_update_result) =
+			self.inner.check_substitute_and_update_state(
+				ctx,
+				subject_client_id,
+				substitute_client_id,
+				*old_client_state.inner,
+				*substitute_client_state.inner,
+			)?;
+		let client_state = ClientState {
+			data: old_client_state.data.clone(),
+			code_id: old_client_state.code_id.clone(),
+			inner: Box::new(inner_client_state),
+			latest_height: old_client_state.latest_height,
+			_phantom: PhantomData,
+		};
+		Ok((client_state, inner_consensus_update_result))
+	}
+
 	fn verify_client_consensus_state<Ctx: ReaderContext>(
 		&self,
 		ctx: &Ctx,

--- a/light-clients/ics08-wasm/src/lib.rs
+++ b/light-clients/ics08-wasm/src/lib.rs
@@ -12,3 +12,5 @@ pub mod consensus_state;
 pub mod msg;
 
 pub type Bytes = Vec<u8>;
+pub static SUBJECT_PREFIX: &[u8] = "subject/".as_bytes();
+pub static SUBSTITUTE_PREFIX: &[u8] = "substitute/".as_bytes();

--- a/light-clients/ics10-grandpa-cw/src/bin/schema.rs
+++ b/light-clients/ics10-grandpa-cw/src/bin/schema.rs
@@ -3,9 +3,9 @@ use cosmwasm_schema::write_api;
 use ics10_grandpa_cw::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 
 fn main() {
-	write_api! {
-		instantiate: InstantiateMsg,
-		execute: ExecuteMsg,
-		query: QueryMsg,
-	}
+	// write_api! {
+	// 	instantiate: InstantiateMsg,
+	// 	execute: ExecuteMsg,
+	// 	query: QueryMsg,
+	// }
 }

--- a/light-clients/ics10-grandpa-cw/src/bin/schema.rs
+++ b/light-clients/ics10-grandpa-cw/src/bin/schema.rs
@@ -3,9 +3,9 @@ use cosmwasm_schema::write_api;
 use ics10_grandpa_cw::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 
 fn main() {
-	// write_api! {
-	// 	instantiate: InstantiateMsg,
-	// 	execute: ExecuteMsg,
-	// 	query: QueryMsg,
-	// }
+	write_api! {
+		instantiate: InstantiateMsg,
+		execute: ExecuteMsg,
+		query: QueryMsg,
+	}
 }

--- a/light-clients/ics10-grandpa-cw/src/client.rs
+++ b/light-clients/ics10-grandpa-cw/src/client.rs
@@ -70,23 +70,8 @@ impl<'a, H: HostFunctions<Header = RelayChainHeader>> ClientReader for Context<'
 	fn client_state(&self, client_id: &ClientId) -> Result<ClientState<H>, Error> {
 		log!(self, "in client : [client_state] >> client_id = {:?}", client_id);
 		let client_states = ReadonlyClientStates::new(self.storage());
-		let data = client_states
-			.get(client_id)
-			.ok_or_else(|| Error::client_not_found(client_id.clone()))?;
-		let any = Any::decode(&*data).map_err(Error::decode)?;
-		let wasm_state =
-			ics08_wasm::client_state::ClientState::<FakeInner, FakeInner, FakeInner>::decode_vec(
-				&any.value,
-			)
-			.map_err(|e| {
-				Error::implementation_specific(format!(
-					"[client_state]: error decoding client state bytes to WasmConsensusState {}",
-					e
-				))
-			})?;
-		let any = Any::decode(&*wasm_state.data).map_err(|e| Error::decode(e))?;
-		let state =
-			ClientState::<H>::decode_vec(&*any.value).map_err(Error::invalid_any_client_state)?;
+		let data = client_states.get().ok_or_else(|| Error::client_not_found(client_id.clone()))?;
+		let state = Self::decode_client_state(&data)?;
 		log!(self, "in client : [client_state] >> any client_state: {:?}", state);
 		Ok(state)
 	}
@@ -96,29 +81,18 @@ impl<'a, H: HostFunctions<Header = RelayChainHeader>> ClientReader for Context<'
 		client_id: &ClientId,
 		height: Height,
 	) -> Result<ConsensusState, Error> {
-		log!(
-			self,
-			"in client : [consensus_state] >> client_id = {:?}, height = {:?}",
-			client_id,
-			height
-		);
+		log!(self, "in client : [consensus_state] >> height = {:?}", height);
 
 		let consensus_states = ReadonlyConsensusStates::new(self.storage());
 		let value = consensus_states
-			.get(client_id, height)
+			.get(height)
 			.ok_or_else(|| Error::consensus_state_not_found(client_id.clone(), height))?;
 		log!(
 			self,
 			"in client : [consensus_state] >> consensus_state (raw): {}",
 			hex::encode(&value)
 		);
-		let any = Any::decode(&mut &value[..]).map_err(Error::decode)?;
-		let wasm_consensus_state =
-			ics08_wasm::consensus_state::ConsensusState::<FakeInner>::decode_vec(&*any.value)
-				.map_err(Error::invalid_any_consensus_state)?;
-		let any = Any::decode(&mut &wasm_consensus_state.data[..]).map_err(Error::decode)?;
-		let any_consensus_state =
-			ConsensusState::decode_vec(&*any.value).map_err(Error::invalid_any_consensus_state)?;
+		let any_consensus_state = Self::decode_consensus_state(&value)?;
 		log!(
 			self,
 			"in client : [consensus_state] >> any consensus state = {:?}",
@@ -209,26 +183,11 @@ impl<'a, H: HostFunctions<Header = RelayChainHeader>> ClientKeeper for Context<'
 	) -> Result<(), Error> {
 		log!(self, "in client : [store_client_state]");
 		let client_states = ReadonlyClientStates::new(self.storage());
-		let data = client_states
-			.get(&client_id)
-			.ok_or_else(|| Error::client_not_found(client_id.clone()))?;
-		let any = Any::decode(&*data).map_err(Error::decode)?;
-		let mut wasm_client_state =
-			ics08_wasm::client_state::ClientState::<FakeInner, FakeInner, FakeInner>::decode_vec(
-				&any.value,
-			)
-			.map_err(|e| {
-				Error::implementation_specific(format!(
-					"[client_state]: error decoding client state bytes to WasmConsensusState {}",
-					e
-				))
-			})?;
-		wasm_client_state.data = client_state.to_any().encode_to_vec();
-		wasm_client_state.latest_height = client_state.latest_height().into();
-		let vec1 = wasm_client_state.to_any().encode_to_vec();
+		let data = client_states.get().ok_or_else(|| Error::client_not_found(client_id.clone()))?;
+		let vec1 = Self::encode_client_state(client_state, data)?;
 		log!(self, "in cliden : [store_client_state] >> wasm client state (raw)");
 		let mut client_state_storage = ClientStates::new(self.storage_mut());
-		client_state_storage.insert(client_id, vec1);
+		client_state_storage.insert(vec1);
 		Ok(())
 	}
 
@@ -245,19 +204,14 @@ impl<'a, H: HostFunctions<Header = RelayChainHeader>> ClientKeeper for Context<'
 			height,
 		);
 
-		let wasm_consensus_state = ics08_wasm::consensus_state::ConsensusState {
-			data: consensus_state.to_any().encode_to_vec(),
-			timestamp: consensus_state.timestamp().nanoseconds(),
-			inner: Box::new(FakeInner),
-		};
-		let vec1 = wasm_consensus_state.to_any().encode_to_vec();
+		let encoded = Self::encode_consensus_state(consensus_state);
 		log!(
 			self,
 			"in client : [store_consensus_state] >> wasm consensus state (raw) = {}",
-			hex::encode(&vec1)
+			hex::encode(&encoded)
 		);
 		let mut consensus_states = ConsensusStates::new(self.storage_mut());
-		consensus_states.insert(client_id, height, vec1);
+		consensus_states.insert(height, encoded);
 		Ok(())
 	}
 
@@ -285,5 +239,66 @@ impl<'a, H: HostFunctions<Header = RelayChainHeader>> ClientKeeper for Context<'
 
 	fn validate_self_client(&self, _client_state: &Self::AnyClientState) -> Result<(), Error> {
 		unimplemented!()
+	}
+}
+
+impl<'a, H: Clone> Context<'a, H> {
+	pub fn decode_client_state(data: &[u8]) -> Result<ClientState<H>, Error> {
+		let any = Any::decode(data).map_err(Error::decode)?;
+		let wasm_state =
+			ics08_wasm::client_state::ClientState::<FakeInner, FakeInner, FakeInner>::decode_vec(
+				&any.value,
+			)
+			.map_err(|e| {
+				Error::implementation_specific(format!(
+					"[client_state]: error decoding client state bytes to WasmConsensusState {}",
+					e
+				))
+			})?;
+		let any = Any::decode(&*wasm_state.data).map_err(|e| Error::decode(e))?;
+		let state =
+			ClientState::<H>::decode_vec(&*any.value).map_err(Error::invalid_any_client_state)?;
+		Ok(state)
+	}
+
+	pub fn decode_consensus_state(value: &[u8]) -> Result<ConsensusState, Error> {
+		let any = Any::decode(&mut &*value).map_err(Error::decode)?;
+		let wasm_consensus_state =
+			ics08_wasm::consensus_state::ConsensusState::<FakeInner>::decode_vec(&*any.value)
+				.map_err(Error::invalid_any_consensus_state)?;
+		let any = Any::decode(&mut &wasm_consensus_state.data[..]).map_err(Error::decode)?;
+		let any_consensus_state =
+			ConsensusState::decode_vec(&*any.value).map_err(Error::invalid_any_consensus_state)?;
+		Ok(any_consensus_state)
+	}
+
+	pub fn encode_client_state(
+		client_state: ClientState<H>,
+		encoded_wasm_client_state: Vec<u8>,
+	) -> Result<Vec<u8>, Error> {
+		let any = Any::decode(&*encoded_wasm_client_state).map_err(Error::decode)?;
+		let mut wasm_client_state =
+			ics08_wasm::client_state::ClientState::<FakeInner, FakeInner, FakeInner>::decode_vec(
+				&any.value,
+			)
+			.map_err(|e| {
+				Error::implementation_specific(format!(
+					"[client_state]: error decoding client state bytes to WasmConsensusState {}",
+					e
+				))
+			})?;
+		wasm_client_state.data = client_state.to_any().encode_to_vec();
+		wasm_client_state.latest_height = client_state.latest_height().into();
+		let vec1 = wasm_client_state.to_any().encode_to_vec();
+		Ok(vec1)
+	}
+
+	pub fn encode_consensus_state(consensus_state: ConsensusState) -> Vec<u8> {
+		let wasm_consensus_state = ics08_wasm::consensus_state::ConsensusState {
+			data: consensus_state.to_any().encode_to_vec(),
+			timestamp: consensus_state.timestamp().nanoseconds(),
+			inner: Box::new(FakeInner),
+		};
+		wasm_consensus_state.to_any().encode_to_vec()
 	}
 }

--- a/light-clients/ics10-grandpa-cw/src/contract.rs
+++ b/light-clients/ics10-grandpa-cw/src/contract.rs
@@ -3,10 +3,11 @@ use crate::{
 	error::ContractError,
 	log,
 	msg::{
-		CheckForMisbehaviourMsg, ClientStateCallResponse, ContractResult, ExecuteMsg,
-		ExportMetadataMsg, InitializeState, InstantiateMsg, QueryMsg, QueryResponse, StatusMsg,
-		UpdateStateMsg, UpdateStateOnMisbehaviourMsg, VerifyClientMessage, VerifyMembershipMsg,
-		VerifyNonMembershipMsg, VerifyUpgradeAndUpdateStateMsg,
+		CheckForMisbehaviourMsg, CheckSubstituteAndUpdateStateMsg, ClientStateCallResponse,
+		ContractResult, ExecuteMsg, ExportMetadataMsg, InitializeState, InstantiateMsg, QueryMsg,
+		QueryResponse, StatusMsg, UpdateStateMsg, UpdateStateOnMisbehaviourMsg,
+		VerifyClientMessage, VerifyMembershipMsg, VerifyNonMembershipMsg,
+		VerifyUpgradeAndUpdateStateMsg,
 	},
 	state::{get_client_state, get_consensus_state},
 	Bytes,
@@ -27,9 +28,11 @@ use ibc::core::{
 	},
 	ics24_host::identifier::ClientId,
 };
+use ics08_wasm::{SUBJECT_PREFIX, SUBSTITUTE_PREFIX};
 use ics10_grandpa::{
 	client_def::GrandpaClient,
 	client_message::{ClientMessage, RelayChainHeader},
+	client_state::ClientState,
 	consensus_state::ConsensusState,
 };
 use light_client_common::{verify_membership, verify_non_membership};
@@ -248,30 +251,50 @@ fn process_message(
 				.update_state(ctx, client_id.clone(), client_state, msg.client_message)
 				.map_err(|e| ContractError::Grandpa(e.to_string()))
 				.and_then(|(cs, cu)| {
-					let height = cs.latest_height();
-					log!(ctx, "Storing client state with height: {:?}", height);
 					ctx.insert_relay_header_hashes(&finalized_headers);
-
-					match cu {
-						ConsensusUpdateResult::Single(cs) => {
-							log!(ctx, "Storing consensus state: {:?}", height);
-							ctx.store_consensus_state(client_id.clone(), height, cs)
-								.map_err(|e| ContractError::Grandpa(e.to_string()))?;
-						},
-						ConsensusUpdateResult::Batch(css) =>
-							for (height, cs) in css {
-								log!(ctx, "Storing consensus state: {:?}", height);
-								ctx.store_consensus_state(client_id.clone(), height, cs)
-									.map_err(|e| ContractError::Grandpa(e.to_string()))?;
-							},
-					}
-					ctx.store_client_state(client_id, cs)
-						.map_err(|e| ContractError::Grandpa(e.to_string()))?;
-					Ok(to_binary(&ContractResult::success()))
+					process_client_and_consensus_states(ctx, client_id.clone(), cs, cu)
 				})
 		},
-		ExecuteMsg::CheckSubstituteAndUpdateState(_msg) => {
-			todo!("check substitute and update state")
+		ExecuteMsg::CheckSubstituteAndUpdateState(msg) => {
+			let _msg = CheckSubstituteAndUpdateStateMsg::try_from(msg)?;
+			let mut old_client_state = ctx
+				.client_state_prefixed(SUBJECT_PREFIX)
+				.map_err(|e| ContractError::Grandpa(e.to_string()))?;
+			let substitute_client_state = ctx
+				.client_state_prefixed(SUBSTITUTE_PREFIX)
+				.map_err(|e| ContractError::Grandpa(e.to_string()))?;
+
+			// Check that the substitute client state is valid:
+			// all fields should be the same, except for the `relay_chain`, `para_id`,
+			// `latest_para_height`, `latest_relay_height`, `frozen_height`, `current_authorities`,
+			// `current_set_id`
+			old_client_state.relay_chain = substitute_client_state.relay_chain;
+			old_client_state.para_id = substitute_client_state.para_id;
+			old_client_state.latest_para_height = substitute_client_state.latest_para_height;
+			old_client_state.latest_relay_height = substitute_client_state.latest_relay_height;
+			old_client_state.frozen_height = substitute_client_state.frozen_height;
+			old_client_state.current_authorities =
+				substitute_client_state.current_authorities.clone();
+			old_client_state.current_set_id = substitute_client_state.current_set_id;
+
+			if old_client_state != substitute_client_state {
+				return Err(ContractError::Grandpa(
+					"subject client state does not match substitute client state".to_string(),
+				))
+			}
+			let substitute_client_state = old_client_state;
+			let height = substitute_client_state.latest_height();
+			let mut substitute_consensus_state =
+				ctx.consensus_state_prefixed(height, SUBSTITUTE_PREFIX)?;
+			substitute_consensus_state.timestamp = substitute_consensus_state
+				.timestamp
+				.checked_add(std::time::Duration::from_nanos(1))
+				.unwrap();
+			ctx.store_consensus_state_prefixed(height, substitute_consensus_state, SUBJECT_PREFIX);
+			ctx.store_client_state_prefixed(substitute_client_state, SUBJECT_PREFIX)
+				.map_err(|e| ContractError::Grandpa(e.to_string()))?;
+
+			Ok(()).map(|_| to_binary(&ContractResult::success()))
 		},
 		ExecuteMsg::VerifyUpgradeAndUpdateState(msg) => {
 			let old_client_state = ctx
@@ -291,23 +314,7 @@ fn process_message(
 				)
 				.map_err(|e| ContractError::Grandpa(e.to_string()))
 				.and_then(|(cs, cu)| {
-					let height = cs.latest_height();
-					match cu {
-						ConsensusUpdateResult::Single(cs) => {
-							log!(ctx, "Storing consensus state: {:?}", height);
-							ctx.store_consensus_state(client_id.clone(), height, cs)
-								.map_err(|e| ContractError::Grandpa(e.to_string()))?;
-						},
-						ConsensusUpdateResult::Batch(css) =>
-							for (height, cs) in css {
-								log!(ctx, "Storing consensus state: {:?}", height);
-								ctx.store_consensus_state(client_id.clone(), height, cs)
-									.map_err(|e| ContractError::Grandpa(e.to_string()))?;
-							},
-					}
-					ctx.store_client_state(client_id, cs)
-						.map_err(|e| ContractError::Grandpa(e.to_string()))?;
-					Ok(to_binary(&ContractResult::success()))
+					process_client_and_consensus_states(ctx, client_id.clone(), cs, cu)
 				})
 		},
 		ExecuteMsg::InitializeState(InitializeState { client_state, consensus_state }) => {
@@ -350,6 +357,35 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
 			}
 		},
 	}
+}
+
+fn process_client_and_consensus_states<H>(
+	ctx: &mut Context<H>,
+	client_id: ClientId,
+	client_state: ClientState<H>,
+	consensus_update: ConsensusUpdateResult<Context<H>>,
+) -> Result<StdResult<Binary>, ContractError>
+where
+	H: grandpa_light_client_primitives::HostFunctions<Header = RelayChainHeader>,
+{
+	let height = client_state.latest_height();
+	match consensus_update {
+		ConsensusUpdateResult::Single(cs) => {
+			log!(ctx, "Storing consensus state: {:?}", height);
+			ctx.store_consensus_state(client_id.clone(), height, cs)
+				.map_err(|e| ContractError::Grandpa(e.to_string()))?;
+		},
+		ConsensusUpdateResult::Batch(css) =>
+			for (height, cs) in css {
+				log!(ctx, "Storing consensus state: {:?}", height);
+				ctx.store_consensus_state(client_id.clone(), height, cs)
+					.map_err(|e| ContractError::Grandpa(e.to_string()))?;
+			},
+	}
+	log!(ctx, "Storing client state with height: {:?}", height);
+	ctx.store_client_state(client_id, client_state)
+		.map_err(|e| ContractError::Grandpa(e.to_string()))?;
+	Ok(to_binary(&ContractResult::success()))
 }
 
 // The FFIs below are required because of sp-io dependency that expects the functions to be

--- a/light-clients/ics10-grandpa-cw/src/contract.rs
+++ b/light-clients/ics10-grandpa-cw/src/contract.rs
@@ -288,10 +288,6 @@ fn process_message(
 			// consensus state should be replaced as well
 			let mut substitute_consensus_state =
 				ctx.consensus_state_prefixed(height, SUBSTITUTE_PREFIX)?;
-			substitute_consensus_state.timestamp = substitute_consensus_state
-				.timestamp
-				.checked_add(std::time::Duration::from_nanos(1))
-				.unwrap();
 			ctx.store_consensus_state_prefixed(height, substitute_consensus_state, SUBJECT_PREFIX);
 			ctx.store_client_state_prefixed(substitute_client_state, SUBJECT_PREFIX)
 				.map_err(|e| ContractError::Grandpa(e.to_string()))?;

--- a/light-clients/ics10-grandpa-cw/src/msg.rs
+++ b/light-clients/ics10-grandpa-cw/src/msg.rs
@@ -118,7 +118,7 @@ pub enum ExecuteMsg {
 	CheckForMisbehaviour(CheckForMisbehaviourMsgRaw),
 	UpdateStateOnMisbehaviour(UpdateStateOnMisbehaviourMsgRaw),
 	UpdateState(UpdateStateMsgRaw),
-	CheckSubstituteAndUpdateState(CheckSubstituteAndUpdateStateMsg),
+	CheckSubstituteAndUpdateState(CheckSubstituteAndUpdateStateMsgRaw),
 	VerifyUpgradeAndUpdateState(VerifyUpgradeAndUpdateStateMsgRaw),
 }
 
@@ -321,8 +321,18 @@ impl TryFrom<UpdateStateMsgRaw> for UpdateStateMsg {
 }
 
 #[cw_serde]
-pub struct CheckSubstituteAndUpdateStateMsg {
-	substitute_client_msg: Vec<u8>,
+pub struct CheckSubstituteAndUpdateStateMsgRaw {}
+
+pub struct CheckSubstituteAndUpdateStateMsg {}
+
+impl TryFrom<CheckSubstituteAndUpdateStateMsgRaw> for CheckSubstituteAndUpdateStateMsg {
+	type Error = ContractError;
+
+	fn try_from(
+		CheckSubstituteAndUpdateStateMsgRaw {}: CheckSubstituteAndUpdateStateMsgRaw,
+	) -> Result<Self, Self::Error> {
+		Ok(Self {})
+	}
 }
 
 #[cw_serde]

--- a/light-clients/ics10-grandpa/src/client_def.rs
+++ b/light-clients/ics10-grandpa/src/client_def.rs
@@ -185,6 +185,7 @@ where
 					))?
 				}
 
+				// first_justification.round
 				let first_valid = first_justification
 					.verify::<H>(client_state.current_set_id, &client_state.current_authorities)
 					.is_ok();
@@ -443,6 +444,17 @@ where
 					.expect("AnyConsensusState is type-checked; qed"),
 			),
 		))
+	}
+
+	fn check_substitute_and_update_state<Ctx: ReaderContext>(
+		&self,
+		_ctx: &Ctx,
+		_subject_client_id: ClientId,
+		_substitute_client_id: ClientId,
+		_old_client_state: Self::ClientState,
+		_substitute_client_state: Self::ClientState,
+	) -> Result<(Self::ClientState, ConsensusUpdateResult<Ctx>), Ics02Error> {
+		unimplemented!("check_substitute_and_update_state not implemented for Grandpa client")
 	}
 
 	fn verify_client_consensus_state<Ctx: ReaderContext>(

--- a/light-clients/ics10-grandpa/src/client_def.rs
+++ b/light-clients/ics10-grandpa/src/client_def.rs
@@ -446,6 +446,13 @@ where
 		))
 	}
 
+	/// Will try to update the client with the state of the substitute.
+	///
+	/// The following must always be true:
+	///   - The substitute client is the same type as the subject client
+	///   - The subject and substitute client states match in all parameters (expect `relay_chain`,
+	/// `para_id`, `latest_para_height`, `latest_relay_height`, `latest_relay_hash`,
+	/// `frozen_height`, `latest_para_height`, `current_set_id` and `current_authorities`).
 	fn check_substitute_and_update_state<Ctx: ReaderContext>(
 		&self,
 		_ctx: &Ctx,

--- a/light-clients/ics10-grandpa/src/client_state.rs
+++ b/light-clients/ics10-grandpa/src/client_state.rs
@@ -23,7 +23,14 @@ use alloc::{format, string::ToString, vec::Vec};
 use anyhow::anyhow;
 use core::{marker::PhantomData, time::Duration};
 use ibc::{
-	core::{ics02_client::client_state::ClientType, ics24_host::identifier::ChainId},
+	core::{
+		ics02_client::{
+			client_consensus::ConsensusState,
+			client_state::{ClientType, Status},
+		},
+		ics24_host::identifier::{ChainId, ClientId},
+		ics26_routing::context::ReaderContext,
+	},
 	Height,
 };
 use ibc_proto::google::protobuf::Any;
@@ -170,6 +177,33 @@ where
 
 	fn latest_height(&self) -> Height {
 		self.latest_height()
+	}
+
+	fn status<Ctx: ReaderContext>(&self, ctx: &Ctx, client_id: &ClientId) -> Status {
+		if self.frozen_height.is_some() {
+			return Status::Frozen
+		}
+
+		// get latest consensus state from clientStore to check for expiry
+		let consensus_state = match ctx.consensus_state(client_id, self.latest_height()) {
+			Ok(consensus_state) => consensus_state,
+			Err(_) => {
+				// if the client state does not have an associated consensus state for its latest
+				// height then it must be expired
+				return Status::Expired
+			},
+		};
+
+		let elapsed = ctx
+			.host_timestamp()
+			.duration_since(&consensus_state.timestamp())
+			.unwrap_or_else(|| Duration::from_secs(0));
+
+		if self.expired(elapsed) {
+			return Status::Expired
+		}
+
+		Status::Active
 	}
 
 	fn frozen_height(&self) -> Option<Height> {

--- a/light-clients/ics10-grandpa/src/tests.rs
+++ b/light-clients/ics10-grandpa/src/tests.rs
@@ -283,7 +283,7 @@ async fn test_continuous_update_of_grandpa_client() {
 				match result {
 					Update(upd_res) => {
 						assert_eq!(upd_res.client_id, client_id);
-						assert!(!upd_res.client_state.is_frozen());
+						assert!(!upd_res.client_state.is_frozen(&ctx, &client_id));
 						assert_eq!(
 							upd_res.client_state,
 							ctx.latest_client_states(&client_id).clone()

--- a/light-clients/ics11-beefy/src/client_def.rs
+++ b/light-clients/ics11-beefy/src/client_def.rs
@@ -250,6 +250,17 @@ where
 		Err(Error::Custom("Beefy Client doesn't need client upgrades".to_string()).into())
 	}
 
+	fn check_substitute_and_update_state<Ctx: ReaderContext>(
+		&self,
+		ctx: &Ctx,
+		subject_client_id: ClientId,
+		substitute_client_id: ClientId,
+		old_client_state: Self::ClientState,
+		substitute_client_state: Self::ClientState,
+	) -> Result<(Self::ClientState, ConsensusUpdateResult<Ctx>), Ics02Error> {
+		Err(Error::Custom("Beefy Client doesn't need client upgrades".to_string()).into())
+	}
+
 	fn verify_client_consensus_state<Ctx: ReaderContext>(
 		&self,
 		_ctx: &Ctx,

--- a/light-clients/ics11-beefy/src/tests.rs
+++ b/light-clients/ics11-beefy/src/tests.rs
@@ -295,7 +295,7 @@ async fn test_continuous_update_of_beefy_client() {
 				match result {
 					Update(upd_res) => {
 						assert_eq!(upd_res.client_id, client_id);
-						assert!(!upd_res.client_state.is_frozen());
+						assert!(!upd_res.client_state.is_frozen(ctx, client_id));
 						assert_eq!(
 							upd_res.client_state,
 							ctx.latest_client_states(&client_id).clone()

--- a/light-clients/ics13-near/src/client_def.rs
+++ b/light-clients/ics13-near/src/client_def.rs
@@ -207,6 +207,17 @@ impl<H: HostFunctionsTrait> ClientDef for NearClient<H> {
 		todo!()
 	}
 
+	fn check_substitute_and_update_state<Ctx: ReaderContext>(
+		&self,
+		ctx: &Ctx,
+		subject_client_id: ClientId,
+		substitute_client_id: ClientId,
+		old_client_state: Self::ClientState,
+		substitute_client_state: Self::ClientState,
+	) -> Result<(Self::ClientState, ConsensusUpdateResult<Ctx>), Error> {
+		todo!()
+	}
+
 	fn verify_client_consensus_state<Ctx: ReaderContext>(
 		&self,
 		_ctx: &Ctx,


### PR DESCRIPTION
- Add `check_substitute_and_update_state` in ibc-rs
- Add `status` method and `Status` type with more granular variants of client's status
- Make Grandpa client expirable