### PR TITLE
Use on-chain storage instead of off-chain

### DIFF
--- a/contracts/pallet-ibc/src/channel.rs
+++ b/contracts/pallet-ibc/src/channel.rs
@@ -304,7 +304,7 @@ where
 		packet_info.height = Some(host_height::<T>());
 		packet_info.channel_order = channel_end.ordering as u8;
 
-		sp_io::offchain_index::set(&key, packet_info.encode().as_slice());
+		SendPackets::<T>::insert(&key, packet_info.encode());
 		log::trace!(target: "pallet_ibc", "in channel: [store_send_packet] >> writing packet {:?} {:?}", key, packet_info);
 		Ok(())
 	}
@@ -323,7 +323,7 @@ where
 		let mut packet_info: PacketInfo = packet.into();
 		packet_info.height = Some(host_height::<T>());
 		packet_info.channel_order = channel_end.ordering as u8;
-		sp_io::offchain_index::set(&key, packet_info.encode().as_slice());
+		RecvPackets::<T>::insert(&key, packet_info.encode());
 		log::trace!(target: "pallet_ibc", "in channel: [store_recv_packet] >> writing packet {:?} {:?}", key, packet_info);
 		Ok(())
 	}

--- a/contracts/pallet-ibc/src/lib.rs
+++ b/contracts/pallet-ibc/src/lib.rs
@@ -363,6 +363,23 @@ pub mod pallet {
 		ValueQuery,
 	>;
 
+	#[pallet::storage]
+	#[allow(clippy::disallowed_types)]
+	/// SendPackets info
+	pub type SendPackets<T: Config> =
+		StorageMap<_, Blake2_128Concat, Vec<u8>, Vec<u8>, OptionQuery>;
+
+	#[pallet::storage]
+	#[allow(clippy::disallowed_types)]
+	/// RecvPackets info
+	pub type RecvPackets<T: Config> =
+		StorageMap<_, Blake2_128Concat, Vec<u8>, Vec<u8>, OptionQuery>;
+
+	#[pallet::storage]
+	#[allow(clippy::disallowed_types)]
+	/// Acks info
+	pub type Acks<T: Config> = StorageMap<_, Blake2_128Concat, Vec<u8>, Vec<u8>, OptionQuery>;
+
 	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 	pub struct AssetConfig<AssetId> {
 		pub id: AssetId,


### PR DESCRIPTION
We have seen that sometimes the state doesn't have the right commitment proofs for a sequence. Our theory is that this is because we are using off chain workers to store some data, and that in the event of forks, we can have a consensus failure.

This change aims to fix this, by moving all critical data away from off-chain worker's storage, and bringing it fully on-chain.