### PR TITLE
Make relay loop reconnect in case channel closes, return error in pallet_ibc::transfer if timeout is zero

### DIFF
--- a/contracts/pallet-ibc/src/lib.rs
+++ b/contracts/pallet-ibc/src/lib.rs
@@ -679,6 +679,10 @@ pub mod pallet {
 				},
 			};
 
+			if timeout_height.is_zero() && timeout_timestamp.nanoseconds() == 0 {
+				return Err(Error::<T>::InvalidTimestamp.into())
+			}
+
 			let msg = MsgTransfer {
 				source_port,
 				source_channel: source_channel.clone(),

--- a/contracts/pallet-ibc/src/lib.rs
+++ b/contracts/pallet-ibc/src/lib.rs
@@ -725,8 +725,6 @@ pub mod pallet {
 				use ibc_primitives::Error::*;
 				match e {
 					SendPacketError { .. } => Error::<T>::TransferSend,
-					// basically that can be anything, as simple as Balance too, but how one may get
-					// error of it?........
 					SendTransferError { .. } => Error::<T>::TransferSend,
 
 					ReceivePacketError { .. } => Error::<T>::TransferProtocol,

--- a/hyperspace/core/src/lib.rs
+++ b/hyperspace/core/src/lib.rs
@@ -51,7 +51,7 @@ where
 	B: Chain,
 {
 	let (mut chain_a_finality, mut chain_b_finality) =
-		(chain_a.finality_notifications().await, chain_b.finality_notifications().await);
+		(chain_a.finality_notifications().await?, chain_b.finality_notifications().await?);
 
 	// If light clients on both chains are not synced then send the old updates and events before
 	// listening for new events

--- a/hyperspace/core/src/lib.rs
+++ b/hyperspace/core/src/lib.rs
@@ -85,23 +85,21 @@ where
 	}
 
 	let (mut chain_a_finality, mut chain_b_finality) =
-		(chain_a.finality_notifications().await, chain_b.finality_notifications().await);
+		(chain_a.finality_notifications().await?, chain_b.finality_notifications().await?);
 
 	// loop forever
 	loop {
 		tokio::select! {
 			// new finality event from chain A
 			result = chain_a_finality.next() => {
-				process_finality_event!(chain_a, chain_b, chain_a_metrics, mode, result)
+				process_finality_event!(chain_a, chain_b, chain_a_metrics, mode, result, chain_a_finality, chain_b_finality)
 			}
 			// new finality event from chain B
 			result = chain_b_finality.next() => {
-				process_finality_event!(chain_b, chain_a, chain_b_metrics, mode, result)
+				process_finality_event!(chain_b, chain_a, chain_b_metrics, mode, result, chain_b_finality, chain_a_finality)
 			}
 		}
 	}
-
-	Ok(())
 }
 
 pub async fn fish<A, B>(chain_a: A, chain_b: B) -> Result<(), anyhow::Error>

--- a/hyperspace/parachain/src/chain.rs
+++ b/hyperspace/parachain/src/chain.rs
@@ -222,7 +222,7 @@ where
 		let call = T::Tx::ibc_deliver(messages);
 		let (ext_hash, block_hash) = self.submit_call(call).await?;
 
-		log::debug!(target: "hyperspace::parachain", "Submitted extrinsic (hash: {:?}) to block {:?}", ext_hash, block_hash);
+		log::debug!(target: "hyperspace_parachain", "Submitted extrinsic (hash: {:?}) to block {:?}", ext_hash, block_hash);
 
 		Ok(TransactionId { ext_hash, block_hash })
 	}

--- a/hyperspace/parachain/src/chain.rs
+++ b/hyperspace/parachain/src/chain.rs
@@ -141,15 +141,17 @@ where
 
 	async fn finality_notifications(
 		&self,
-	) -> Pin<Box<dyn Stream<Item = <Self as IbcProvider>::FinalityEvent> + Send + Sync>> {
+	) -> Result<
+		Pin<Box<dyn Stream<Item = <Self as IbcProvider>::FinalityEvent> + Send + Sync>>,
+		Error,
+	> {
 		match self.finality_protocol {
 			FinalityProtocol::Grandpa => {
 				let subscription =
 					GrandpaApiClient::<JustificationNotification, sp_core::H256, u32>::subscribe_justifications(
 						&*self.relay_ws_client,
 					)
-						.await
-						.expect("Failed to subscribe to grandpa justifications")
+						.await?
 						.chunks(3)
 						.map(|mut notifs| notifs.remove(notifs.len() - 1)); // skip every 3 finality notifications
 
@@ -174,7 +176,7 @@ where
 					futures::future::ready(Some(Self::FinalityEvent::Grandpa(justification)))
 				});
 
-				Box::pin(Box::new(stream))
+				Ok(Box::pin(Box::new(stream)))
 			},
 			FinalityProtocol::Beefy => {
 				let subscription =
@@ -204,7 +206,7 @@ where
 					futures::future::ready(Some(Self::FinalityEvent::Beefy(signed_commitment)))
 				});
 
-				Box::pin(Box::new(stream))
+				Ok(Box::pin(Box::new(stream)))
 			},
 		}
 	}

--- a/hyperspace/parachain/src/provider.rs
+++ b/hyperspace/parachain/src/provider.rs
@@ -413,7 +413,7 @@ where
 		seqs: Vec<u64>,
 	) -> Result<Vec<u64>, Self::Error> {
 		log::trace!(
-			target: "hyperspace::parachain",
+			target: "hyperspace_parachain",
 			"query_unreceived_acknowledgements at: {:?}, channel_id: {:?}, port_id: {:?}, seqs: {:?}",
 			at,
 			channel_id,
@@ -499,7 +499,7 @@ where
 		client_height: Height,
 	) -> Result<(Height, Timestamp), Self::Error> {
 		log::trace!(
-			target: "hyperspace::parachain",
+			target: "hyperspace_parachain",
 			"Querying client update time and height for client {:?} at height {:?}",
 			client_id,
 			client_height

--- a/hyperspace/primitives/src/lib.rs
+++ b/hyperspace/primitives/src/lib.rs
@@ -431,7 +431,7 @@ pub trait Chain:
 	/// Return a stream that yields when new [`IbcEvents`] are ready to be queried.
 	async fn finality_notifications(
 		&self,
-	) -> Pin<Box<dyn Stream<Item = Self::FinalityEvent> + Send + Sync>>;
+	) -> Result<Pin<Box<dyn Stream<Item = Self::FinalityEvent> + Send + Sync>>, Self::Error>;
 
 	/// This should be used to submit new messages [`Vec<Any>`] from a counterparty chain to this
 	/// chain.

--- a/hyperspace/testsuite/src/lib.rs
+++ b/hyperspace/testsuite/src/lib.rs
@@ -478,7 +478,7 @@ async fn send_packet_and_assert_timeout_on_channel_close<A, B>(
 
 	set_relay_status(true);
 
-	assert_timeout_packet(chain_a, 50).await;
+	assert_timeout_packet(chain_a, 70).await;
 	log::info!(target: "hyperspace", "🚀🚀 Timeout packet successfully processed for channel close");
 }
 

--- a/hyperspace/testsuite/src/lib.rs
+++ b/hyperspace/testsuite/src/lib.rs
@@ -287,7 +287,7 @@ async fn send_packet_and_assert_height_timeout<A, B>(
 	log::info!(target: "hyperspace", "Resuming send packet relay");
 	set_relay_status(true);
 
-	assert_timeout_packet(chain_a, 35).await;
+	assert_timeout_packet(chain_a, 50).await;
 	log::info!(target: "hyperspace", "🚀🚀 Timeout packet successfully processed for height timeout");
 }
 

--- a/hyperspace/testsuite/src/misbehaviour.rs
+++ b/hyperspace/testsuite/src/misbehaviour.rs
@@ -61,7 +61,8 @@ where
 		_ => panic!("unexpected client state"),
 	};
 
-	let finality_event = chain_b.finality_notifications().await.next().await.expect("no event");
+	let finality_event =
+		chain_b.finality_notifications().await.unwrap().next().await.expect("no event");
 	let set_id = client_state.current_set_id;
 
 	// construct an extrinsic proof with the mandatory timestamp extrinsic


### PR DESCRIPTION
- The loop was breaking if the stream was ended, now it infinitely tries to reconnect each 30 seconds
- Return an error from pallet_ibc::transfer if both timeout timestamp and timeout height are zero