### PR TITLE
pallet-ibc: send fee to its own address

### DIFF
--- a/contracts/pallet-ibc/src/ics20_fee/mod.rs
+++ b/contracts/pallet-ibc/src/ics20_fee/mod.rs
@@ -228,7 +228,6 @@ where
 					.map_err(|_| {
 					Ics04Error::implementation_specific("Failed to receiver account".to_string())
 				})?;
-			let pallet_account = Pallet::<T>::account_id();
 			let mut prefixed_coin = if is_receiver_chain_source(
 				packet.source_port.clone(),
 				packet.source_channel,
@@ -248,7 +247,8 @@ where
 			prefixed_coin.amount = fee.into();
 			// Now we proceed to send the service fee from the receiver's account to the pallet
 			// account
-			ctx.send_coins(&receiver, &pallet_account, &prefixed_coin)
+			let fee_account = T::FeeAccount::get();
+			ctx.send_coins(&receiver, &fee_account, &prefixed_coin)
 				.map_err(|e| Ics04Error::app_module(e.to_string()))?;
 			// We modify the packet data to remove the fee so any other middleware has access to the
 			// correct amount deposited in the receiver's account

--- a/contracts/pallet-ibc/src/lib.rs
+++ b/contracts/pallet-ibc/src/lib.rs
@@ -264,6 +264,8 @@ pub mod pallet {
 
 		type IsSendEnabled: Get<bool>;
 		type IsReceiveEnabled: Get<bool>;
+
+		type FeeAccount: Get<Self::AccountIdConversion>;
 	}
 
 	#[pallet::pallet]

--- a/contracts/pallet-ibc/src/mock.rs
+++ b/contracts/pallet-ibc/src/mock.rs
@@ -10,7 +10,7 @@ use frame_support::{
 };
 use frame_system as system;
 use frame_system::EnsureSigned;
-use ibc_primitives::IbcAccount;
+use ibc_primitives::{runtime_interface::ss58_to_account_id_32, IbcAccount};
 use light_client_common::RelayChain;
 use orml_traits::parameter_type_with_key;
 use sp_core::{
@@ -205,11 +205,19 @@ impl Config for Test {
 	type IsReceiveEnabled = sp_core::ConstBool<true>;
 	type IsSendEnabled = sp_core::ConstBool<true>;
 	type Ics20RateLimiter = Everything;
+	type FeeAccount = FeeAccount;
 }
 
 parameter_types! {
 	pub const ServiceCharge: Perbill = Perbill::from_percent(1);
 	pub const PalletId: frame_support::PalletId = frame_support::PalletId(*b"ics20fee");
+	pub FeeAccount: <Test as Config>::AccountIdConversion = create_alice_key();
+}
+
+fn create_alice_key() -> <Test as Config>::AccountIdConversion {
+	let alice = "5yNZjX24n2eg7W6EVamaTXNQbWCwchhThEaSWB7V3GRjtHeL";
+	let account_id_32 = ss58_to_account_id_32(alice).unwrap().into();
+	IbcAccount(account_id_32)
 }
 
 impl crate::ics20_fee::Config for Test {


### PR DESCRIPTION
This address can or cannot be the same as the account id of the pallet.
Gives flexibility.