### PR TITLE
Fix IBC transfers when using router

### DIFF
--- a/contracts/pallet-ibc/src/ics20/memo.rs
+++ b/contracts/pallet-ibc/src/ics20/memo.rs
@@ -198,5 +198,6 @@ impl<T: Config + Send + Sync, S: Module + Clone + Default + PartialEq + Eq + Deb
 		<T as Config>::HandleMemo::execute_memo(&packet_data, receiver).map_err(|e| {
 			Error::implementation_specific(format!("Failed to execute memo {:?}", e))
 		})?;
+		Ok(())
 	}
 }

--- a/contracts/pallet-ibc/src/ics20/memo.rs
+++ b/contracts/pallet-ibc/src/ics20/memo.rs
@@ -153,18 +153,11 @@ impl<T: Config + Send + Sync, S: Module + Clone + Default + PartialEq + Eq + Deb
 		relayer: &Signer,
 	) -> Result<Acknowledgement, Error> {
 		let ack = self.inner.on_recv_packet(ctx, output, packet, relayer)?;
-		let packet_data: PacketData =
-			serde_json::from_slice(packet.data.as_slice()).map_err(|e| {
-				Error::implementation_specific(format!("Failed to decode packet data {:?}", e))
-			})?;
-		let receiver = <T as Config>::AccountIdConversion::try_from(packet_data.receiver.clone())
-			.map_err(|_| {
-				Error::implementation_specific(format!("Failed to parse receiver account"))
-			})?
-			.into_account();
-		<T as Config>::HandleMemo::execute_memo(&packet_data, receiver).map_err(|e| {
-			Error::implementation_specific(format!("Failed to execute memo {:?}", e))
-		})?;
+		// We want the whole chain of calls to fail only if the ics20 transfer fails, because
+		// the other modules are not part of ics-20 standard
+		let _ = Self::process_memo(packet).map_err(|e| {
+			log::error!(target: "pallet_ibc", "Error while handling memo: {:?}", e);
+		});
 		Ok(ack)
 	}
 
@@ -188,5 +181,22 @@ impl<T: Config + Send + Sync, S: Module + Clone + Default + PartialEq + Eq + Deb
 		relayer: &Signer,
 	) -> Result<(), Error> {
 		self.inner.on_timeout_packet(ctx, output, packet, relayer)
+	}
+}
+
+impl<T: Config + Send + Sync, S: Module + Clone + Default + PartialEq + Eq + Debug> Memo<T, S> {
+	fn process_memo(packet: &mut Packet) -> Result<(), Error> {
+		let packet_data: PacketData =
+			serde_json::from_slice(packet.data.as_slice()).map_err(|e| {
+				Error::implementation_specific(format!("Failed to decode packet data {:?}", e))
+			})?;
+		let receiver = <T as Config>::AccountIdConversion::try_from(packet_data.receiver.clone())
+			.map_err(|_| {
+				Error::implementation_specific(format!("Failed to parse receiver account"))
+			})?
+			.into_account();
+		<T as Config>::HandleMemo::execute_memo(&packet_data, receiver).map_err(|e| {
+			Error::implementation_specific(format!("Failed to execute memo {:?}", e))
+		})?;
 	}
 }

--- a/contracts/pallet-ibc/src/ics20_fee/mod.rs
+++ b/contracts/pallet-ibc/src/ics20_fee/mod.rs
@@ -207,6 +207,44 @@ where
 		packet: &mut Packet,
 		relayer: &Signer,
 	) -> Result<Acknowledgement, Ics04Error> {
+		let ack = self.inner.on_recv_packet(&mut ctx, output, packet, relayer)?;
+		// We want the whole chain of calls to fail only if the ics20 transfer fails, because
+		// the other modules are not part of ics-20 standard
+		let _ = Self::process_fee(packet, &ack).map_err(|e| {
+			log::error!(target: "pallet_ibc", "Error processing fee: {:?}", e);
+		});
+		Ok(ack)
+	}
+
+	fn on_acknowledgement_packet(
+		&mut self,
+		ctx: &dyn ModuleCallbackContext,
+		output: &mut ModuleOutputBuilder,
+		packet: &mut Packet,
+		acknowledgement: &Acknowledgement,
+		relayer: &Signer,
+	) -> Result<(), Ics04Error> {
+		self.inner
+			.on_acknowledgement_packet(ctx, output, packet, acknowledgement, relayer)
+	}
+
+	fn on_timeout_packet(
+		&mut self,
+		ctx: &dyn ModuleCallbackContext,
+		output: &mut ModuleOutputBuilder,
+		packet: &mut Packet,
+		relayer: &Signer,
+	) -> Result<(), Ics04Error> {
+		self.inner.on_timeout_packet(ctx, output, packet, relayer)
+	}
+}
+
+impl<T: Config + Send + Sync, S: Module + Clone + Default + PartialEq + Eq + Debug>
+	Ics20ServiceCharge<T, S>
+where
+	<T as crate::Config>::AccountIdConversion: From<IbcAccount<T::AccountId>>,
+{
+	fn process_fee(packet: &mut Packet, ack: &Acknowledgement) -> Result<(), Ics04Error> {
 		// Module ModuleCallbackContext does not have the ics20 context as part of its trait bounds
 		// so we define a new context
 		let mut ctx = Context::<T>::default();
@@ -216,7 +254,6 @@ where
 			})?;
 		let percent = ServiceCharge::<T>::get().unwrap_or(T::ServiceCharge::get());
 		// Send full amount to receiver using the default ics20 logic
-		let ack = self.inner.on_recv_packet(&mut ctx, output, packet, relayer)?;
 		// We only take the fee charge if the acknowledgement is not an error
 		if ack.as_ref() == Ics20Ack::success().to_string().as_bytes() {
 			// We have ensured that token amounts larger than the max value for a u128 are rejected
@@ -259,28 +296,6 @@ where
 			})?;
 			Pallet::<T>::deposit_event(Event::<T>::IbcTransferFeeCollected { amount: fee.into() })
 		}
-		Ok(ack)
-	}
-
-	fn on_acknowledgement_packet(
-		&mut self,
-		ctx: &dyn ModuleCallbackContext,
-		output: &mut ModuleOutputBuilder,
-		packet: &mut Packet,
-		acknowledgement: &Acknowledgement,
-		relayer: &Signer,
-	) -> Result<(), Ics04Error> {
-		self.inner
-			.on_acknowledgement_packet(ctx, output, packet, acknowledgement, relayer)
-	}
-
-	fn on_timeout_packet(
-		&mut self,
-		ctx: &dyn ModuleCallbackContext,
-		output: &mut ModuleOutputBuilder,
-		packet: &mut Packet,
-		relayer: &Signer,
-	) -> Result<(), Ics04Error> {
-		self.inner.on_timeout_packet(ctx, output, packet, relayer)
+		Ok(())
 	}
 }

--- a/contracts/pallet-ibc/src/tests.rs
+++ b/contracts/pallet-ibc/src/tests.rs
@@ -337,20 +337,141 @@ fn on_deliver_ics20_recv_packet() {
 
 		let msg = Any { type_url: msg.type_url(), value: msg.encode_vec().unwrap() };
 
-		let account_data = Assets::balance(2u128, AccountId32::new(pair.public().0));
+		let account_data = Assets::balance(asset_id, AccountId32::new(pair.public().0));
 		// Assert account balance before transfer
 		assert_eq!(account_data, 0);
 		Ibc::deliver(RuntimeOrigin::signed(AccountId32::new([0; 32])), vec![msg]).unwrap();
 
 		let balance =
-			<Assets as Inspect<AccountId>>::balance(2, &AccountId32::new(pair.public().0));
+			<Assets as Inspect<AccountId>>::balance(asset_id, &AccountId32::new(pair.public().0));
 		let pallet_balance = <Assets as Inspect<AccountId>>::balance(
-			2,
+			asset_id,
 			&<Test as crate::Config>::FeeAccount::get().into_account(),
 		);
 		let fee = <Test as crate::ics20_fee::Config>::ServiceCharge::get() * amt;
 		assert_eq!(balance, amt - fee);
 		assert_eq!(pallet_balance, fee)
+	})
+}
+
+#[test]
+fn on_deliver_ics20_recv_packet_should_not_double_spend() {
+	let mut ext = new_test_ext();
+	ext.execute_with(|| {
+		// Create  a new account
+		let pair = sp_core::sr25519::Pair::from_seed(b"12345678901234567890123456789012");
+		let ss58_address_bytes =
+			ibc_primitives::runtime_interface::account_id_to_ss58(pair.public().0, 49);
+		let ss58_address = String::from_utf8(ss58_address_bytes).unwrap();
+		frame_system::Pallet::<Test>::set_block_number(1u32);
+		let asset_id =
+			<<Test as Config>::IbcDenomToAssetIdConversion as DenomToAssetId<Test>>::from_denom_to_asset_id(
+				&"PICA".to_string(),
+			)
+			.unwrap();
+		setup_client_and_consensus_state(PortId::transfer());
+
+		let channel_id = ChannelId::new(0);
+		let balance = 100000 * MILLIS;
+
+		// We are simulating a transfer back to the source chain
+
+		let denom = "transfer/channel-1/PICA";
+		let channel_escrow_address =
+			get_channel_escrow_address(&PortId::transfer(), channel_id).unwrap();
+		let channel_escrow_address =
+			<Test as Config>::AccountIdConversion::try_from(channel_escrow_address)
+				.map_err(|_| ())
+				.unwrap();
+		let channel_escrow_address = channel_escrow_address.into_account();
+
+		// Endow escrow address with tokens
+		<<Test as Config>::Fungibles as Mutate<
+			<Test as frame_system::Config>::AccountId,
+		>>::mint_into(asset_id, &channel_escrow_address, balance)
+		.unwrap();
+
+		let prefixed_denom = PrefixedDenom::from_str(denom).unwrap();
+		let amt = MILLIS / 100;
+		println!("Transferred Amount {}", amt);
+		let coin = Coin {
+			denom: prefixed_denom,
+			amount: ibc::applications::transfer::Amount::from_str(&format!("{:?}", amt)).unwrap(),
+		};
+		let packet_data = PacketData {
+			token: coin,
+			sender: Signer::from_str("alice").unwrap(),
+			receiver: Signer::from_str(&ss58_address).unwrap(),
+			memo: "".to_string(),
+		};
+
+		let data = serde_json::to_vec(&packet_data).unwrap();
+		let packet = Packet {
+			sequence: 1u64.into(),
+			source_port: PortId::transfer(),
+			source_channel: ChannelId::new(1),
+			destination_port: PortId::transfer(),
+			destination_channel: ChannelId::new(0),
+			data,
+			timeout_height: Height::new(2000, 5),
+			timeout_timestamp: ibc::timestamp::Timestamp::from_nanoseconds(
+				1690894363u64.saturating_mul(1000000000),
+			)
+			.unwrap(),
+		};
+
+		let msg = MsgRecvPacket {
+			packet,
+			proofs: Proofs::new(
+				vec![0u8; 32].try_into().unwrap(),
+				None,
+				None,
+				None,
+				Height::new(0, 1),
+			)
+			.unwrap(),
+			signer: Signer::from_str(MODULE_ID).unwrap(),
+		};
+
+		let msg = Any { type_url: msg.type_url(), value: msg.encode_vec().unwrap() };
+
+		let account_data = Assets::balance(asset_id, AccountId32::new(pair.public().0));
+		// Assert account balance before transfer
+		assert_eq!(account_data, 0);
+		Ibc::deliver(RuntimeOrigin::signed(AccountId32::new([0; 32])), vec![msg.clone()]).unwrap();
+
+		let account_data = Assets::balance(asset_id, AccountId32::new(pair.public().0));
+		// Assert account balance after transfer
+		assert_eq!(account_data, amt);
+
+		let balance =
+			<Assets as Inspect<AccountId>>::balance(asset_id, &AccountId32::new(pair.public().0));
+		let pallet_balance = <Assets as Inspect<AccountId>>::balance(
+			asset_id,
+			&<Test as crate::Config>::FeeAccount::get().into_account(),
+		);
+		// fee is less than ExistentialDeposit, so it is not deducted
+		let fee = 0;
+		assert_eq!(balance, amt);
+		assert_eq!(pallet_balance, fee);
+
+		// try sending the same packet again
+		Ibc::deliver(RuntimeOrigin::signed(AccountId32::new([0; 32])), vec![msg]).unwrap();
+
+		let account_data = Assets::balance(asset_id, AccountId32::new(pair.public().0));
+		// Assert account balance after transfer
+		assert_eq!(account_data, amt);
+
+		let balance =
+			<Assets as Inspect<AccountId>>::balance(asset_id, &AccountId32::new(pair.public().0));
+		let pallet_balance = <Assets as Inspect<AccountId>>::balance(
+			asset_id,
+			&<Test as crate::Config>::FeeAccount::get().into_account(),
+		);
+		// fee is less than ExistentialDeposit, so it is not deducted
+		let fee = 0;
+		assert_eq!(balance, amt);
+		assert_eq!(pallet_balance, fee);
 	})
 }
 


### PR DESCRIPTION
There is an issue that if one of the cascaded calls in the router fails, the whole packet is considered failed. But since we don't rollback the previous changes (e.g. an ics-20 transfer), the packet state becomes invalid and may cause some weird issues, e.g. allowing to submit the same packet multiple times, receiving more tokens each time (double spending).

It's currently not clear whether it's possible to allow other modules to fail in case we have pre-checked all the sub-calls in the beginning, because then there is a possibility to mark a good packet (from the ics-20 module's point of view) as failed, although, it shouldn't fail in reality, because initially, the process of fee collection and memo execution was not defined in the standard.