### PR TITLE
Flat fee fix for small transferred amount and  non IBC location assets id

### DIFF
--- a/contracts/pallet-ibc/src/ics20_fee/mod.rs
+++ b/contracts/pallet-ibc/src/ics20_fee/mod.rs
@@ -1,6 +1,6 @@
 use crate::{routing::Context, DenomToAssetId};
 use alloc::{format, string::ToString};
-use core::fmt::Debug;
+use core::{fmt::Debug, marker::PhantomData};
 use ibc::{
 	applications::transfer::{
 		acknowledgement::Acknowledgement as Ics20Ack, context::BankKeeper,

--- a/contracts/pallet-ibc/src/ics20_fee/mod.rs
+++ b/contracts/pallet-ibc/src/ics20_fee/mod.rs
@@ -301,7 +301,6 @@ where
 		// Send full amount to receiver using the default ics20 logic
 		// We only take the fee charge if the acknowledgement is not an error
 		if ack.as_ref() == Ics20Ack::success().to_string().as_bytes() {
-
 			let mut prefixed_coin = if is_receiver_chain_source(
 				packet.source_port.clone(),
 				packet.source_channel,

--- a/contracts/pallet-ibc/src/mock.rs
+++ b/contracts/pallet-ibc/src/mock.rs
@@ -225,8 +225,8 @@ impl<T: Config> FlatFeeConverter for FlatFeeConverterDummy<T> {
 	type Balance = u128;
 	fn get_flat_fee(
 		asset_id: Self::AssetId,
-		fee_asset_id: Self::AssetId,
-		fee_asset_amount: Self::Balance,
+		_fee_asset_id: Self::AssetId,
+		_fee_asset_amount: Self::Balance,
 	) -> Option<u128> {
 		if asset_id == 3 {
 			return Some(1000)

--- a/contracts/pallet-ibc/src/tests.rs
+++ b/contracts/pallet-ibc/src/tests.rs
@@ -460,6 +460,118 @@ fn on_deliver_ics20_recv_packet_with_flat_fee() {
 }
 
 #[test]
+fn on_deliver_ics20_recv_packet_transfered_amount_less_then_flat_fee() {
+	let mut ext = new_test_ext();
+	ext.execute_with(|| {
+		// Create  a new account
+		let pair = sp_core::sr25519::Pair::from_seed(b"12345678901234567890123456789012");
+		let ss58_address_bytes =
+			ibc_primitives::runtime_interface::account_id_to_ss58(pair.public().0, 49);
+		let ss58_address = String::from_utf8(ss58_address_bytes).unwrap();
+		frame_system::Pallet::<Test>::set_block_number(1u32);
+		let asset_id =
+			<<Test as Config>::IbcDenomToAssetIdConversion as DenomToAssetId<Test>>::from_denom_to_asset_id(
+				&"PICAFLATFEE".to_string(),
+			)
+			.unwrap();
+		setup_client_and_consensus_state(PortId::transfer());
+
+		let channel_id = ChannelId::new(0);
+		let balance = 100000 * MILLIS;
+
+		// We are simulating a transfer back to the source chain
+
+		let denom = "transfer/channel-1/PICAFLATFEE";
+		let channel_escrow_address =
+			get_channel_escrow_address(&PortId::transfer(), channel_id).unwrap();
+		let channel_escrow_address =
+			<Test as Config>::AccountIdConversion::try_from(channel_escrow_address)
+				.map_err(|_| ())
+				.unwrap();
+		let channel_escrow_address = channel_escrow_address.into_account();
+
+		// Endow escrow address with tokens
+		<<Test as Config>::Fungibles as Mutate<
+			<Test as frame_system::Config>::AccountId,
+		>>::mint_into(asset_id, &channel_escrow_address, balance)
+		.unwrap();
+
+		let prefixed_denom = PrefixedDenom::from_str(denom).unwrap();
+		let usdt_fee_amount = 1000 * MILLIS;
+		let fee_asset_id = <Test as crate::ics20_fee::Config>::FlatFeeAssetId::get();
+		let amt = <Test as crate::ics20_fee::Config>::FlatFeeConverter::get_flat_fee(
+			asset_id,
+			fee_asset_id,
+			usdt_fee_amount,
+		)
+		.unwrap_or_default();
+		println!("Transferred Amount {}", amt);
+		let coin = Coin {
+			denom: prefixed_denom,
+			amount: ibc::applications::transfer::Amount::from_str(&format!("{:?}", amt)).unwrap(),
+		};
+		let packet_data = PacketData {
+			token: coin,
+			sender: Signer::from_str("alice").unwrap(),
+			receiver: Signer::from_str(&ss58_address).unwrap(),
+			memo: "".to_string(),
+		};
+
+		let data = serde_json::to_vec(&packet_data).unwrap();
+		let packet = Packet {
+			sequence: 1u64.into(),
+			source_port: PortId::transfer(),
+			source_channel: ChannelId::new(1),
+			destination_port: PortId::transfer(),
+			destination_channel: ChannelId::new(0),
+			data,
+			timeout_height: Height::new(2000, 5),
+			timeout_timestamp: ibc::timestamp::Timestamp::from_nanoseconds(
+				1690894363u64.saturating_mul(1000000000),
+			)
+			.unwrap(),
+		};
+
+		let msg = MsgRecvPacket {
+			packet,
+			proofs: Proofs::new(
+				vec![0u8; 32].try_into().unwrap(),
+				None,
+				None,
+				None,
+				Height::new(0, 1),
+			)
+			.unwrap(),
+			signer: Signer::from_str(MODULE_ID).unwrap(),
+		};
+
+		let msg = Any { type_url: msg.type_url(), value: msg.encode_vec().unwrap() };
+
+		let account_data = Assets::balance(asset_id, AccountId32::new(pair.public().0));
+		// Assert account balance before transfer
+		assert_eq!(account_data, 0);
+		Ibc::deliver(RuntimeOrigin::signed(AccountId32::new([0; 32])), vec![msg]).unwrap();
+
+		let balance =
+			<Assets as Inspect<AccountId>>::balance(asset_id, &AccountId32::new(pair.public().0));
+		let pallet_balance = <Assets as Inspect<AccountId>>::balance(
+			asset_id,
+			&<Test as crate::Config>::FeeAccount::get().into_account(),
+		);
+		let fee = <Test as crate::ics20_fee::Config>::FlatFeeConverter::get_flat_fee(
+			asset_id,
+			fee_asset_id,
+			usdt_fee_amount,
+		)
+		.unwrap_or_default();
+		let actual_fee = fee.min(amt);
+		assert_eq!(balance, 0);
+		assert_eq!(balance, amt - actual_fee);
+		assert_eq!(pallet_balance, actual_fee);
+	})
+}
+
+#[test]
 fn on_deliver_ics20_recv_packet_should_not_double_spend() {
 	let mut ext = new_test_ext();
 	ext.execute_with(|| {


### PR DESCRIPTION
This PR fix two issue : 
- https://github.com/ComposableFi/composable/issues/3564
- https://github.com/ComposableFi/composable/issues/3565

- move `prefixed_coin` up to use adjusted `denom` value to find `asset_id`
- use `min` function to avoid underflow when subtract fee from transferred amount `fee = fee.min(amount);`
- added unit test to cover test case when transferred amount less then flat fee 