### PR TITLE
Charge IBC fee on sender chain if channels are not whitelisted

### DIFF
--- a/contracts/pallet-ibc/src/ics20/mod.rs
+++ b/contracts/pallet-ibc/src/ics20/mod.rs
@@ -2,8 +2,7 @@ pub mod context;
 pub mod memo;
 
 use crate::{
-	routing::Context, ChannelIds, Config, DenomToAssetId, Event, Pallet, SequenceFee,
-	WeightInfo,
+	routing::Context, ChannelIds, Config, DenomToAssetId, Event, Pallet, SequenceFee, WeightInfo,
 };
 use alloc::{
 	format,

--- a/contracts/pallet-ibc/src/ics20/mod.rs
+++ b/contracts/pallet-ibc/src/ics20/mod.rs
@@ -463,12 +463,12 @@ where
 
 		fee_coin.amount = U256::from(fee).into();
 
-		let singer_from = packet_data.sender.clone();
+		let signer_from = packet_data.sender.clone();
 		let refund_to_account_id =
-			<T as Config>::AccountIdConversion::try_from(singer_from.clone()).map_err(|_| {
+			<T as Config>::AccountIdConversion::try_from(signer_from.clone()).map_err(|_| {
 				Ics04Error::implementation_specific(format!(
 					"Failed to parse receiver account {:?}",
-					singer_from
+					signer_from
 				))
 			})?;
 
@@ -476,7 +476,7 @@ where
 				log::debug!(target: "pallet_ibc", "[{}]: error when refund the fee : {:?} for sequence {}", &e, fee, sequence);
 				Ics04Error::implementation_specific(format!(
 					"Failed to refund fee to sender account {:?}, fee : {} , sequence : {} ",
-					singer_from, fee, sequence
+					signer_from, fee, sequence
 				))
 			})?;
 		Ok(())

--- a/contracts/pallet-ibc/src/ics20/mod.rs
+++ b/contracts/pallet-ibc/src/ics20/mod.rs
@@ -17,7 +17,7 @@ use ibc::{
 		acknowledgement::{Acknowledgement as Ics20Acknowledgement, ACK_ERR_STR},
 		context::{
 			on_chan_close_confirm, on_chan_close_init, on_chan_open_ack, on_chan_open_confirm,
-			on_chan_open_init, on_chan_open_try,
+			on_chan_open_init, on_chan_open_try, BankKeeper,
 		},
 		is_receiver_chain_source, is_sender_chain_source,
 		packet::PacketData,
@@ -349,36 +349,12 @@ where
 				})
 			},
 			Err(e) => {
-				use ibc::{applications::transfer::context::BankKeeper, bigint::U256};
-				use sp_core::Get;
-
 				log::trace!(
 					target: "pallet_ibc::transfer",
 					"error: acknowledgement error: {e}",
 				);
-				let sequence: u64 = packet.sequence.into();
-				if <Pallet<T> as Store>::SequenceFee::contains_key(sequence) {
-					let fee = <Pallet<T> as Store>::SequenceFee::get(sequence);
+				Self::refund_fee(packet, &packet_data, "on_acknowledgement_packet")?;
 
-					let fee_account = T::FeeAccount::get();
-
-					let mut ctx = Context::<T>::default();
-					let mut fee_coin = packet_data.token.clone();
-
-					fee_coin.amount = U256::from(fee).into();
-
-					let singer_from = packet_data.sender.clone();
-					let Ok(account_id_from) = <T as Config>::AccountIdConversion::try_from(singer_from) else{
-					todo!();
-				};
-
-					let _ =
-						ctx.send_coins(&fee_account, &account_id_from, &fee_coin).map_err(|e| {
-							log::debug!(target: "pallet_ibc", "[transfer]: error: {:?}", &e);
-							// Error::<T>::FailedSendFeeToAccount
-							//todo ask what todo if we are not able to refunc fee back
-						});
-				}
 				Pallet::<T>::deposit_event(Event::<T>::TokenTransferFailed {
 					from: packet_data.sender,
 					to: packet_data.receiver,
@@ -414,6 +390,9 @@ where
 			.map_err(|e| Ics04Error::app_module(format!("Failed to decode packet data {:?}", e)))?;
 		process_timeout_packet(&mut ctx, packet, &packet_data)
 			.map_err(|e| Ics04Error::app_module(e.to_string()))?;
+
+		Self::refund_fee(packet, &packet_data, "on_timeout_packet")?;
+
 		Pallet::<T>::deposit_event(Event::<T>::TokenTransferTimeout {
 			from: packet_data.sender,
 			to: packet_data.receiver,
@@ -432,6 +411,48 @@ where
 			destination_channel: packet.destination_channel.to_string().as_bytes().to_vec(),
 		});
 		Ok(())
+	}
+}
+
+impl<T> IbcModule<T>
+where
+	T: Config + Send + Sync,
+	u32: From<<T as frame_system::Config>::BlockNumber>,
+	AccountId32: From<<T as frame_system::Config>::AccountId>,
+{
+	fn refund_fee(
+		packet: &Packet,
+		packet_data: &PacketData,
+		callback_name: &str,
+	) -> Result<(), Ics04Error> {
+		use ibc::bigint::U256;
+		use sp_core::Get;
+		let sequence: u64 = packet.sequence.into();
+		Ok(if <Pallet<T> as Store>::SequenceFee::contains_key(sequence) {
+			let fee = <Pallet<T> as Store>::SequenceFee::get(sequence);
+
+			let fee_account = T::FeeAccount::get();
+
+			let mut ctx = Context::<T>::default();
+			let mut fee_coin = packet_data.token.clone();
+
+			fee_coin.amount = U256::from(fee).into();
+
+			let singer_from = packet_data.sender.clone();
+			let refund_to_account_id = <T as Config>::AccountIdConversion::try_from(
+				singer_from.clone(),
+			)
+			.map_err(|_| {
+				Ics04Error::implementation_specific(format!(
+					"Failed to parse receiver account {:?}",
+					singer_from
+				))
+			})?;
+
+			let _ = ctx.send_coins(&fee_account, &refund_to_account_id, &fee_coin).map_err(|e| {
+				log::debug!(target: "pallet_ibc", "[{}]: error when refund the fee: {:?}", callback_name, &e);
+			});
+		})
 	}
 }
 

--- a/contracts/pallet-ibc/src/ics20/mod.rs
+++ b/contracts/pallet-ibc/src/ics20/mod.rs
@@ -329,6 +329,7 @@ where
 				let sequence: u64 = packet.sequence.into();
 				if <Pallet<T> as Store>::SequenceFee::contains_key(sequence) {
 					<Pallet<T> as Store>::SequenceFee::remove(sequence);
+					Pallet::<T>::deposit_event(Event::<T>::ChargingFeeConfirmed { sequence });
 				}
 				Pallet::<T>::deposit_event(Event::<T>::TokenTransferCompleted {
 					from: packet_data.sender,
@@ -452,6 +453,13 @@ where
 			let _ = ctx.send_coins(&fee_account, &refund_to_account_id, &fee_coin).map_err(|e| {
 				log::debug!(target: "pallet_ibc", "[{}]: error when refund the fee: {:?}", callback_name, &e);
 			});
+			let event;
+			if callback_name == "on_acknowledgement_packet" {
+				event = Event::<T>::ChargingFeeFailedAcknowledgement { sequence };
+			} else {
+				event = Event::<T>::ChargingFeeTimeout { sequence };
+			}
+			Pallet::<T>::deposit_event(event);
 		})
 	}
 }

--- a/contracts/pallet-ibc/src/ics20/mod.rs
+++ b/contracts/pallet-ibc/src/ics20/mod.rs
@@ -2,7 +2,8 @@ pub mod context;
 pub mod memo;
 
 use crate::{
-	routing::Context, ChannelIds, Config, DenomToAssetId, Event, Pallet, Store, WeightInfo,
+	routing::Context, ChannelIds, Config, DenomToAssetId, Event, Pallet, SequenceFee,
+	WeightInfo,
 };
 use alloc::{
 	format,
@@ -327,8 +328,8 @@ where
 			.map_err(|e| Ics04Error::implementation_specific(e.to_string()))?;
 		match ack.into_result() {
 			Ok(_) => {
-				if crate::SequenceFee::<T>::contains_key(sequence) {
-					<Pallet<T> as Store>::SequenceFee::remove(sequence);
+				if SequenceFee::<T>::contains_key(sequence) {
+					SequenceFee::<T>::remove(sequence);
 					Pallet::<T>::deposit_event(Event::<T>::ChargingFeeConfirmed { sequence });
 				}
 				Pallet::<T>::deposit_event(Event::<T>::TokenTransferCompleted {
@@ -450,10 +451,10 @@ where
 		use ibc::bigint::U256;
 		use sp_core::Get;
 		let sequence: u64 = packet.sequence.into();
-		if !<Pallet<T> as Store>::SequenceFee::contains_key(sequence) {
+		if !SequenceFee::<T>::contains_key(sequence) {
 			return Ok(()) //there is nothing to refund.
 		}
-		let fee = <Pallet<T> as Store>::SequenceFee::take(sequence);
+		let fee = SequenceFee::<T>::take(sequence);
 
 		let fee_account = T::FeeAccount::get();
 

--- a/contracts/pallet-ibc/src/ics20/mod.rs
+++ b/contracts/pallet-ibc/src/ics20/mod.rs
@@ -330,7 +330,6 @@ where
 				if <Pallet<T> as Store>::SequenceFee::contains_key(sequence) {
 					<Pallet<T> as Store>::SequenceFee::remove(sequence);
 				}
-				// <Pallet<T> as Store>::SequenceFee::try_mutate_exists
 				Pallet::<T>::deposit_event(Event::<T>::TokenTransferCompleted {
 					from: packet_data.sender,
 					to: packet_data.receiver,

--- a/contracts/pallet-ibc/src/ics20_fee/mod.rs
+++ b/contracts/pallet-ibc/src/ics20_fee/mod.rs
@@ -41,6 +41,17 @@ pub mod pallet {
 		/// The overarching event type.
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 		#[pallet::constant]
+		/// `ServiceChargeIn` represents the service charge rate applied to assets upon receipt via
+		/// IBC.
+		///
+		/// The charge is applied when assets are delivered to the receiving side, on
+		/// deliver(before to mint, send assets to destination account) extrinsic using the
+		/// Inter-Blockchain Communication (IBC) protocol.
+		///
+		/// For example, if the service charge rate for incoming assets is 0.04%, `ServiceChargeIn`
+		/// will be configured in rutime as
+		/// parameter_types! { pub IbcIcs20ServiceChargeIn: Perbill = Perbill::from_rational(4_u32,
+		/// 1000_u32 ) };
 		type ServiceChargeIn: Get<Perbill>;
 		#[pallet::constant]
 		type PalletId: Get<PalletId>;

--- a/contracts/pallet-ibc/src/ics20_fee/mod.rs
+++ b/contracts/pallet-ibc/src/ics20_fee/mod.rs
@@ -28,7 +28,6 @@ pub use pallet::*;
 
 #[frame_support::pallet]
 pub mod pallet {
-	use super::FlatFeeConverter;
 	use frame_support::{pallet_prelude::*, PalletId};
 	use frame_system::pallet_prelude::OriginFor;
 	use ibc_primitives::IbcAccount;
@@ -46,15 +45,15 @@ pub mod pallet {
 		#[pallet::constant]
 		type PalletId: Get<PalletId>;
 
-		type FlatFeeConverter: FlatFeeConverter<
-			AssetId = <Self as crate::Config>::AssetId,
-			Balance = <Self as crate::Config>::Balance,
-		>;
+		// type FlatFeeConverter: FlatFeeConverter<
+		// 	AssetId = <Self as crate::Config>::AssetId,
+		// 	Balance = <Self as crate::Config>::Balance,
+		// >;
 
-		//Asset Id for fee that will charged. for example  USDT
-		type FlatFeeAssetId: Get<<Self as crate::Config>::AssetId>;
-		//Asset amount that will be charged. for example 10 (USDT)
-		type FlatFeeAmount: Get<<Self as crate::Config>::Balance>;
+		// //Asset Id for fee that will charged. for example  USDT
+		// type FlatFeeAssetId: Get<<Self as crate::Config>::AssetId>;
+		// //Asset amount that will be charged. for example 10 (USDT)
+		// type FlatFeeAmount: Get<<Self as crate::Config>::Balance>;
 	}
 
 	#[pallet::pallet]

--- a/contracts/pallet-ibc/src/ics20_fee/mod.rs
+++ b/contracts/pallet-ibc/src/ics20_fee/mod.rs
@@ -41,7 +41,7 @@ pub mod pallet {
 		/// The overarching event type.
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 		#[pallet::constant]
-		type ServiceCharge: Get<Perbill>;
+		type ServiceChargeIn: Get<Perbill>;
 		#[pallet::constant]
 		type PalletId: Get<PalletId>;
 	}
@@ -52,7 +52,7 @@ pub mod pallet {
 	pub struct Pallet<T>(_);
 
 	#[pallet::storage]
-	pub type ServiceCharge<T: Config> = StorageValue<_, Perbill, OptionQuery>;
+	pub type ServiceChargeIn<T: Config> = StorageValue<_, Perbill, OptionQuery>;
 
 	#[pallet::storage]
 	#[allow(clippy::disallowed_types)]
@@ -75,7 +75,7 @@ pub mod pallet {
 		#[pallet::weight(0)]
 		pub fn set_charge(origin: OriginFor<T>, charge: Perbill) -> DispatchResult {
 			<T as crate::Config>::AdminOrigin::ensure_origin(origin)?;
-			<ServiceCharge<T>>::put(charge);
+			<ServiceChargeIn<T>>::put(charge);
 			Ok(())
 		}
 
@@ -343,8 +343,7 @@ where
 			return Ok(())
 		}
 
-		let percent =
-			ServiceCharge::<T>::get().unwrap_or(<T as pallet::Config>::ServiceCharge::get());
+		let percent = ServiceChargeIn::<T>::get().unwrap_or(T::ServiceChargeIn::get());
 		// Send full amount to receiver using the default ics20 logic
 		// We only take the fee charge if the acknowledgement is not an error
 		if ack.as_ref() == Ics20Ack::success().to_string().as_bytes() {

--- a/contracts/pallet-ibc/src/ics20_fee/mod.rs
+++ b/contracts/pallet-ibc/src/ics20_fee/mod.rs
@@ -297,7 +297,8 @@ where
 			.map_err(|e| {
 				Ics04Error::implementation_specific(format!("Failed to decode packet data {:?}", e))
 			})?;
-		let percent = ServiceCharge::<T>::get().unwrap_or(T::ServiceCharge::get());
+		let percent =
+			ServiceCharge::<T>::get().unwrap_or(<T as pallet::Config>::ServiceCharge::get());
 		// Send full amount to receiver using the default ics20 logic
 		// We only take the fee charge if the acknowledgement is not an error
 		if ack.as_ref() == Ics20Ack::success().to_string().as_bytes() {

--- a/contracts/pallet-ibc/src/ics20_fee/mod.rs
+++ b/contracts/pallet-ibc/src/ics20_fee/mod.rs
@@ -345,7 +345,7 @@ where
 				Ics04Error::implementation_specific(format!("Failed to decode packet data {:?}", e))
 			})?;
 
-		let is_whitelisted = <FeeLessChannelIds<T>>::contains_key((
+		let is_whitelisted = FeeLessChannelIds::<T>::contains_key((
 			packet.source_channel.sequence(),
 			packet.destination_channel.sequence(),
 		));

--- a/contracts/pallet-ibc/src/ics20_fee/mod.rs
+++ b/contracts/pallet-ibc/src/ics20_fee/mod.rs
@@ -154,7 +154,7 @@ pub trait FlatFeeConverter {
 
 pub struct NonFlatFeeConverter<T>(PhantomData<T>);
 
-impl<T: Config> FlatFeeConverter for NonFlatFeeConverter<T> {
+impl<T: crate::Config> FlatFeeConverter for NonFlatFeeConverter<T> {
 	type AssetId = T::AssetId;
 	type Balance = T::Balance;
 
@@ -345,12 +345,12 @@ where
 				Ics04Error::implementation_specific(format!("Failed to decode packet data {:?}", e))
 			})?;
 
-		let is_whitelisted = FeeLessChannelIds::<T>::contains_key((
+		let is_feeless_channels = FeeLessChannelIds::<T>::contains_key((
 			packet.source_channel.sequence(),
 			packet.destination_channel.sequence(),
 		));
 
-		if is_whitelisted {
+		if is_feeless_channels {
 			return Ok(())
 		}
 

--- a/contracts/pallet-ibc/src/lib.rs
+++ b/contracts/pallet-ibc/src/lib.rs
@@ -274,7 +274,7 @@ pub mod pallet {
 		type CleanUpPacketsPeriod: Get<Self::BlockNumber>;
 
 		#[pallet::constant]
-		type ServiceCharge: Get<Perbill>;
+		type ServiceChargeOut: Get<Perbill>;
 
 		type FlatFeeConverter: FlatFeeConverter<
 			AssetId = <Self as crate::Config>::AssetId,
@@ -305,7 +305,7 @@ pub mod pallet {
 	>;
 
 	#[pallet::storage]
-	pub type ServiceCharge<T: Config> = StorageValue<_, Perbill, OptionQuery>;
+	pub type ServiceChargeOut<T: Config> = StorageValue<_, Perbill, OptionQuery>;
 
 	#[pallet::storage]
 	/// client_id , Height => Timestamp
@@ -822,7 +822,7 @@ pub mod pallet {
 			));
 
 			if !whitelisted {
-				let percent = ServiceCharge::<T>::get().unwrap_or(T::ServiceCharge::get());
+				let percent = ServiceChargeOut::<T>::get().unwrap_or(T::ServiceChargeOut::get());
 				// Now we proceed to send the service fee from the receiver's account to the pallet
 				// FeeAccount
 				let fee_account = T::FeeAccount::get();

--- a/contracts/pallet-ibc/src/lib.rs
+++ b/contracts/pallet-ibc/src/lib.rs
@@ -177,10 +177,10 @@ pub mod pallet {
 	use light_clients::AnyClientState;
 	use sp_runtime::{
 		traits::{IdentifyAccount, Saturating, Zero},
-		AccountId32, BoundedBTreeSet,
+		AccountId32, BoundedBTreeSet, Perbill,
 	};
 	#[cfg(feature = "std")]
-	use sp_runtime::{Deserialize, Perbill, Serialize};
+	use sp_runtime::{Deserialize, Serialize};
 	use sp_std::collections::btree_set::BTreeSet;
 
 	/// Configure the pallet by specifying the parameters and types on which it depends.

--- a/contracts/pallet-ibc/src/lib.rs
+++ b/contracts/pallet-ibc/src/lib.rs
@@ -274,6 +274,17 @@ pub mod pallet {
 		type CleanUpPacketsPeriod: Get<Self::BlockNumber>;
 
 		#[pallet::constant]
+		/// `ServiceChargeOut` represents the service charge rate applied to assets that will be
+		/// sent via IBC.
+		///
+		/// The charge is applied before assets are transffered from the sender side, during
+		/// transfer extrinsic (before to burn or send assets to escrow account) before the packet
+		/// send via IBC Inter-Blockchain Communication (IBC) protocol.
+		///
+		/// For example, if the service charge rate for incoming assets is 0.04%, `ServiceChargeIn`
+		/// will be configured in rutime as
+		/// parameter_types! { pub IbcIcs20ServiceChargeOut: Perbill = Perbill::from_rational(4_u32,
+		/// 1000_u32 ) };
 		type ServiceChargeOut: Get<Perbill>;
 
 		type FlatFeeConverter: FlatFeeConverter<

--- a/contracts/pallet-ibc/src/lib.rs
+++ b/contracts/pallet-ibc/src/lib.rs
@@ -731,6 +731,7 @@ pub mod pallet {
 				source_channel.sequence(),
 				destination_channel.sequence(),
 			));
+
 			if !whitelisted {
 				let percent = ServiceCharge::<T>::get().unwrap_or(T::ServiceCharge::get());
 				// Now we proceed to send the service fee from the receiver's account to the pallet

--- a/contracts/pallet-ibc/src/lib.rs
+++ b/contracts/pallet-ibc/src/lib.rs
@@ -340,8 +340,8 @@ pub mod pallet {
 	#[pallet::storage]
 	#[allow(clippy::disallowed_types)]
 	/// storage map. key is tuple of (source_channel.sequence(), destination_channel.sequence()) and
-	/// value () that means that this group of channels is whitelisted
-	pub type WhitelistChannelIds<T: Config> =
+	/// value () that means that this group of channels is feeless
+	pub type FeeLessChannelIds<T: Config> =
 		StorageMap<_, Blake2_128Concat, (u64, u64), (), ValueQuery>;
 
 	#[pallet::storage]
@@ -559,11 +559,11 @@ pub mod pallet {
 			admin_account: <T as frame_system::Config>::AccountId,
 		},
 
-		ChannelsFeeWhitelistAdded {
+		FeeLessChannelIdsAdded {
 			source_channel: u64,
 			destination_channel: u64,
 		},
-		ChannelsFeeWhitelistRemoved {
+		FeeLessChannelIdsRemoved {
 			source_channel: u64,
 			destination_channel: u64,
 		},
@@ -827,12 +827,12 @@ pub mod pallet {
 				.channel_id
 				.ok_or_else(|| Error::<T>::ChannelNotFound)?;
 
-			let whitelisted = <WhitelistChannelIds<T>>::contains_key((
+			let is_feeless_channel_ids = <FeeLessChannelIds<T>>::contains_key((
 				source_channel.sequence(),
 				destination_channel.sequence(),
 			));
 
-			if !whitelisted {
+			if !is_feeless_channel_ids {
 				let percent = ServiceChargeOut::<T>::get().unwrap_or(T::ServiceChargeOut::get());
 				// Now we proceed to send the service fee from the receiver's account to the pallet
 				// FeeAccount
@@ -1091,15 +1091,15 @@ pub mod pallet {
 		#[pallet::call_index(6)]
 		#[pallet::weight(0)]
 		#[frame_support::transactional]
-		pub fn add_channels_to_free_fee_whitelist(
+		pub fn add_channels_to_feeless_channel_list(
 			origin: OriginFor<T>,
 			source_channel: u64,
 			destination_channel: u64,
 		) -> DispatchResult {
 			ensure_root(origin)?;
 
-			<WhitelistChannelIds<T>>::insert((source_channel, destination_channel), ());
-			Self::deposit_event(Event::<T>::ChannelsFeeWhitelistAdded {
+			FeeLessChannelIds::<T>::insert((source_channel, destination_channel), ());
+			Self::deposit_event(Event::<T>::FeeLessChannelIdsAdded {
 				source_channel,
 				destination_channel,
 			});
@@ -1110,15 +1110,15 @@ pub mod pallet {
 		#[pallet::call_index(7)]
 		#[pallet::weight(0)]
 		#[frame_support::transactional]
-		pub fn remove_channels_from_free_fee_whitelist(
+		pub fn remove_channels_from_feeless_channel_list(
 			origin: OriginFor<T>,
 			source_channel: u64,
 			destination_channel: u64,
 		) -> DispatchResult {
 			ensure_root(origin)?;
 
-			<WhitelistChannelIds<T>>::remove((source_channel, destination_channel));
-			Self::deposit_event(Event::<T>::ChannelsFeeWhitelistRemoved {
+			FeeLessChannelIds::<T>::remove((source_channel, destination_channel));
+			Self::deposit_event(Event::<T>::FeeLessChannelIdsRemoved {
 				source_channel,
 				destination_channel,
 			});

--- a/contracts/pallet-ibc/src/lib.rs
+++ b/contracts/pallet-ibc/src/lib.rs
@@ -576,6 +576,8 @@ pub mod pallet {
 		RateLimiter,
 		//Fee errors
 		FailedSendFeeToAccount,
+		//Failed to derive origin sender address.
+		OriginAddress,
 	}
 
 	#[pallet::hooks]
@@ -742,10 +744,8 @@ pub mod pallet {
 				fee_coin.amount = U256::from(fee).into();
 
 				let singer_from = Signer::from_str(&from).map_err(|_| Error::<T>::Utf8Error)?;
-				let Ok(account_id_from) = <T as Config>::AccountIdConversion::try_from(singer_from) else {
-					// return Error::<T>::ProcessingError;
-					todo!();
-				};
+				let account_id_from = <T as Config>::AccountIdConversion::try_from(singer_from)
+					.map_err(|_| Error::<T>::OriginAddress)?;
 
 				ctx.send_coins(&account_id_from, &fee_account, &fee_coin).map_err(|e| {
 					log::debug!(target: "pallet_ibc", "[transfer]: error: {:?}", &e);

--- a/contracts/pallet-ibc/src/lib.rs
+++ b/contracts/pallet-ibc/src/lib.rs
@@ -574,6 +574,8 @@ pub mod pallet {
 		/// Access denied
 		AccessDenied,
 		RateLimiter,
+		//Fee errors
+		FailedSendFeeToAccount,
 	}
 
 	#[pallet::hooks]
@@ -745,11 +747,10 @@ pub mod pallet {
 					todo!();
 				};
 
-				let result_send = ctx.send_coins(&account_id_from, &fee_account, &fee_coin);
-				if let Err(e) = result_send {
-					//return error.
-					todo!();
-				};
+				ctx.send_coins(&account_id_from, &fee_account, &fee_coin).map_err(|e| {
+					log::debug!(target: "pallet_ibc", "[transfer]: error: {:?}", &e);
+					Error::<T>::FailedSendFeeToAccount
+				})?;
 
 				// We modify the packet data to remove the fee so any other middleware has access to
 				// the correct amount deposited in the receiver's account

--- a/contracts/pallet-ibc/src/lib.rs
+++ b/contracts/pallet-ibc/src/lib.rs
@@ -567,6 +567,15 @@ pub mod pallet {
 			source_channel: Vec<u8>,
 			destination_channel: Vec<u8>,
 		},
+		ChargingFeeConfirmed {
+			sequence: u64,
+		},
+		ChargingFeeTimeout {
+			sequence: u64,
+		},
+		ChargingFeeFailedAcknowledgement {
+			sequence: u64,
+		},
 	}
 
 	/// Errors inform users that something went wrong.

--- a/contracts/pallet-ibc/src/lib.rs
+++ b/contracts/pallet-ibc/src/lib.rs
@@ -827,7 +827,7 @@ pub mod pallet {
 				.channel_id
 				.ok_or_else(|| Error::<T>::ChannelNotFound)?;
 
-			let is_feeless_channel_ids = <FeeLessChannelIds<T>>::contains_key((
+			let is_feeless_channel_ids = FeeLessChannelIds::<T>::contains_key((
 				source_channel.sequence(),
 				destination_channel.sequence(),
 			));

--- a/contracts/pallet-ibc/src/mock.rs
+++ b/contracts/pallet-ibc/src/mock.rs
@@ -219,6 +219,10 @@ impl Config for Test {
 	type Ics20RateLimiter = Everything;
 	type FeeAccount = FeeAccount;
 	type CleanUpPacketsPeriod = CleanUpPacketsPeriod;
+	type ServiceCharge = ServiceCharge;
+	type FlatFeeConverter = FlatFeeConverterDummy<Test>;
+	type FlatFeeAssetId = FlatFeeAssetId;
+	type FlatFeeAmount = FlatFeeAmount;
 }
 #[derive(Debug, Clone)]
 pub struct FlatFeeConverterDummy<T: Config>(PhantomData<T>);
@@ -240,9 +244,6 @@ impl crate::ics20_fee::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type ServiceCharge = ServiceCharge;
 	type PalletId = PalletId;
-	type FlatFeeConverter = FlatFeeConverterDummy<Test>;
-	type FlatFeeAssetId = FlatFeeAssetId;
-	type FlatFeeAmount = FlatFeeAmount;
 }
 
 #[derive(

--- a/contracts/pallet-ibc/src/mock.rs
+++ b/contracts/pallet-ibc/src/mock.rs
@@ -219,7 +219,7 @@ impl Config for Test {
 	type Ics20RateLimiter = Everything;
 	type FeeAccount = FeeAccount;
 	type CleanUpPacketsPeriod = CleanUpPacketsPeriod;
-	type ServiceCharge = ServiceCharge;
+	type ServiceChargeOut = ServiceCharge;
 	type FlatFeeConverter = FlatFeeConverterDummy<Test>;
 	type FlatFeeAssetId = FlatFeeAssetId;
 	type FlatFeeAmount = FlatFeeAmount;
@@ -242,7 +242,7 @@ impl<T: Config> FlatFeeConverter for FlatFeeConverterDummy<T> {
 }
 impl crate::ics20_fee::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
-	type ServiceCharge = ServiceCharge;
+	type ServiceChargeIn = ServiceCharge;
 	type PalletId = PalletId;
 }
 

--- a/contracts/pallet-ibc/src/tests.rs
+++ b/contracts/pallet-ibc/src/tests.rs
@@ -2,8 +2,8 @@ use crate::{
 	light_clients::{AnyClientState, AnyConsensusState},
 	mock::*,
 	routing::Context,
-	Any, Config, ConsensusHeights, DenomToAssetId, MultiAddress, Pallet, PendingRecvPacketSeqs,
-	PendingSendPacketSeqs, Timeout, TransferParams, MODULE_ID,
+	Any, Config, ConsensusHeights, DenomToAssetId, FlatFeeConverter, MultiAddress, Pallet,
+	PendingRecvPacketSeqs, PendingSendPacketSeqs, Timeout, TransferParams, MODULE_ID,
 };
 use core::time::Duration;
 use frame_support::{
@@ -446,13 +446,10 @@ fn on_deliver_ics20_recv_packet_with_flat_fee() {
 			asset_id,
 			&<Test as crate::Config>::FeeAccount::get().into_account(),
 		);
-		let fee_asset_id = <Test as crate::ics20_fee::Config>::FlatFeeAssetId::get();
-		let fee = <Test as crate::ics20_fee::Config>::FlatFeeConverter::get_flat_fee(
-			asset_id,
-			fee_asset_id,
-			amt,
-		)
-		.unwrap_or_default();
+		let fee_asset_id = <Test as crate::Config>::FlatFeeAssetId::get();
+		let fee =
+			<Test as crate::Config>::FlatFeeConverter::get_flat_fee(asset_id, fee_asset_id, amt)
+				.unwrap_or_default();
 		assert_eq!(balance, amt - fee);
 		assert_eq!(pallet_balance, fee)
 	})
@@ -497,8 +494,8 @@ fn on_deliver_ics20_recv_packet_transfered_amount_less_then_flat_fee() {
 
 		let prefixed_denom = PrefixedDenom::from_str(denom).unwrap();
 		let usdt_fee_amount = 1000 * MILLIS;
-		let fee_asset_id = <Test as crate::ics20_fee::Config>::FlatFeeAssetId::get();
-		let amt = <Test as crate::ics20_fee::Config>::FlatFeeConverter::get_flat_fee(
+		let fee_asset_id = <Test as crate::Config>::FlatFeeAssetId::get();
+		let amt = <Test as crate::Config>::FlatFeeConverter::get_flat_fee(
 			asset_id,
 			fee_asset_id,
 			usdt_fee_amount,
@@ -557,7 +554,7 @@ fn on_deliver_ics20_recv_packet_transfered_amount_less_then_flat_fee() {
 			asset_id,
 			&<Test as crate::Config>::FeeAccount::get().into_account(),
 		);
-		let fee = <Test as crate::ics20_fee::Config>::FlatFeeConverter::get_flat_fee(
+		let fee = <Test as crate::Config>::FlatFeeConverter::get_flat_fee(
 			asset_id,
 			fee_asset_id,
 			usdt_fee_amount,

--- a/contracts/pallet-ibc/src/tests.rs
+++ b/contracts/pallet-ibc/src/tests.rs
@@ -256,7 +256,7 @@ fn send_transfer() {
 
 		let packet_data: PacketData = serde_json::from_slice(packet_info.data.as_slice()).unwrap();
 		let send_amount = packet_data.token.amount.as_u256().as_u128();
-		let fee = <Test as crate::ics20_fee::Config>::ServiceCharge::get() * balance;
+		let fee = <Test as crate::ics20_fee::Config>::ServiceChargeIn::get() * balance;
 		assert_eq!(send_amount, balance - fee);
 	})
 }
@@ -422,7 +422,7 @@ fn on_deliver_ics20_recv_packet() {
 			asset_id,
 			&<Test as crate::Config>::FeeAccount::get().into_account(),
 		);
-		let fee = <Test as crate::ics20_fee::Config>::ServiceCharge::get() * amt;
+		let fee = <Test as crate::ics20_fee::Config>::ServiceChargeIn::get() * amt;
 		assert_eq!(balance, amt - fee);
 		assert_eq!(pallet_balance, fee)
 	})

--- a/contracts/pallet-ibc/src/tests.rs
+++ b/contracts/pallet-ibc/src/tests.rs
@@ -31,7 +31,7 @@ use ibc::{
 		},
 		ics04_channel::{
 			channel::{ChannelEnd, Counterparty as ChanCounterParty, Order, State},
-			context::ChannelKeeper,
+			context::{ChannelKeeper, ChannelReader},
 			msgs::recv_packet::MsgRecvPacket,
 			packet::Packet,
 			Version as ChanVersion,
@@ -258,6 +258,75 @@ fn send_transfer() {
 		let send_amount = packet_data.token.amount.as_u256().as_u128();
 		let fee = <Test as crate::ics20_fee::Config>::ServiceCharge::get() * balance;
 		assert_eq!(send_amount, balance - fee);
+	})
+}
+
+#[test]
+fn send_transfer_no_fee_whitelisted_channels() {
+	let mut ext = new_test_ext();
+	let balance = 100000 * MILLIS;
+	ext.execute_with(|| {
+		let pair = sp_core::sr25519::Pair::from_seed(b"12345678901234567890123456789012");
+		let raw_user = ibc_primitives::runtime_interface::account_id_to_ss58(pair.public().0, 49);
+		let ss58_address = String::from_utf8(raw_user).unwrap();
+		setup_client_and_consensus_state(PortId::transfer());
+		let asset_id =
+			<<Test as Config>::IbcDenomToAssetIdConversion as DenomToAssetId<Test>>::from_denom_to_asset_id(
+				&"PICA".to_string(),
+			)
+			.unwrap();
+		<<Test as Config>::Fungibles as Mutate<
+			<Test as frame_system::Config>::AccountId,
+		>>::mint_into(asset_id, &AccountId32::new([0; 32]), balance).unwrap();
+
+		let timeout = Timeout::Offset { timestamp: Some(1000), height: Some(5) };
+
+		let ctx = Context::<Test>::default();
+		let channel_end = ctx
+			.channel_end(&(PortId::transfer(), ChannelId::new(0)))
+			.expect("expect source_channel unwrap");
+		let destination_channel = channel_end.counterparty().channel_id.unwrap();
+		//whitelist channels
+		let _ = Ibc::add_channels_to_free_fee_whitelist(
+			RuntimeOrigin::root(),
+			0,
+			destination_channel.sequence(),
+		)
+		.expect("expect add channels to whitelist");
+
+		Ibc::transfer(
+			RuntimeOrigin::signed(AccountId32::new([0; 32])),
+			TransferParams {
+				to: MultiAddress::Raw(ss58_address.as_bytes().to_vec()),
+				source_channel: 0,
+				timeout,
+			},
+			asset_id,
+			balance,
+			None,
+		)
+		.unwrap();
+	});
+
+	ext.persist_offchain_overlay();
+
+	ext.execute_with(|| {
+		let channel_id = ChannelId::new(0);
+		let port_id = PortId::transfer();
+		let packet_info = Pallet::<Test>::get_send_packet_info(
+			channel_id.to_string().as_bytes().to_vec(),
+			port_id.as_bytes().to_vec(),
+			vec![1],
+		)
+		.unwrap()
+		.get(0)
+		.unwrap()
+		.clone();
+		assert!(!packet_info.data.is_empty());
+
+		let packet_data: PacketData = serde_json::from_slice(packet_info.data.as_slice()).unwrap();
+		let send_amount = packet_data.token.amount.as_u256().as_u128();
+		assert_eq!(send_amount, balance);
 	})
 }
 

--- a/contracts/pallet-ibc/src/tests.rs
+++ b/contracts/pallet-ibc/src/tests.rs
@@ -262,7 +262,7 @@ fn send_transfer() {
 }
 
 #[test]
-fn send_transfer_no_fee_whitelisted_channels() {
+fn send_transfer_no_fee_feeless_channels() {
 	let mut ext = new_test_ext();
 	let balance = 100000 * MILLIS;
 	ext.execute_with(|| {
@@ -286,13 +286,13 @@ fn send_transfer_no_fee_whitelisted_channels() {
 			.channel_end(&(PortId::transfer(), ChannelId::new(0)))
 			.expect("expect source_channel unwrap");
 		let destination_channel = channel_end.counterparty().channel_id.unwrap();
-		//whitelist channels
-		let _ = Ibc::add_channels_to_free_fee_whitelist(
+		//feeless channels
+		let _ = Ibc::add_channels_to_feeless_channel_list(
 			RuntimeOrigin::root(),
 			0,
 			destination_channel.sequence(),
 		)
-		.expect("expect add channels to whitelist");
+		.expect("expect add channels to feeless list");
 
 		Ibc::transfer(
 			RuntimeOrigin::signed(AccountId32::new([0; 32])),

--- a/contracts/pallet-ibc/src/tests.rs
+++ b/contracts/pallet-ibc/src/tests.rs
@@ -3,8 +3,8 @@ use crate::{
 	light_clients::{AnyClientState, AnyConsensusState},
 	mock::*,
 	routing::Context,
-	Any, Config, ConsensusHeights, DenomToAssetId, MultiAddress, Pallet,
-	PendingRecvPacketSeqs, PendingSendPacketSeqs, Timeout, TransferParams, MODULE_ID,
+	Any, Config, ConsensusHeights, DenomToAssetId, MultiAddress, Pallet, PendingRecvPacketSeqs,
+	PendingSendPacketSeqs, Timeout, TransferParams, MODULE_ID,
 };
 use core::time::Duration;
 use frame_support::{

--- a/contracts/pallet-ibc/src/tests.rs
+++ b/contracts/pallet-ibc/src/tests.rs
@@ -3,7 +3,7 @@ use crate::{
 	light_clients::{AnyClientState, AnyConsensusState},
 	mock::*,
 	routing::Context,
-	Any, Config, ConsensusHeights, DenomToAssetId, FlatFeeConverter, MultiAddress, Pallet,
+	Any, Config, ConsensusHeights, DenomToAssetId, MultiAddress, Pallet,
 	PendingRecvPacketSeqs, PendingSendPacketSeqs, Timeout, TransferParams, MODULE_ID,
 };
 use core::time::Duration;

--- a/utils/parachain-node/runtime/src/lib.rs
+++ b/utils/parachain-node/runtime/src/lib.rs
@@ -707,7 +707,7 @@ parameter_types! {
 	pub const CleanUpPacketsPeriod: BlockNumber = 100;
 	pub AssetIdUSDT: AssetId = 0;
 	pub FlatFeeUSDTAmount: Balance = 0;
-	pub IbcIcs20ServiceCharge: Perbill = Perbill::from_rational(4_u32, 1000_u32 );
+	pub IbcIcs20ServiceCharge: Perbill = Perbill::from_rational(0_u32, 1000_u32 );
 }
 
 fn create_alice_key() -> <Runtime as pallet_ibc::Config>::AccountIdConversion {

--- a/utils/parachain-node/runtime/src/lib.rs
+++ b/utils/parachain-node/runtime/src/lib.rs
@@ -37,7 +37,9 @@ use ibc::core::{
 };
 use ibc_primitives::{runtime_interface::ss58_to_account_id_32, IbcAccount};
 use orml_traits::asset_registry::AssetProcessor;
-use pallet_ibc::{light_client_common::RelayChain, LightClientProtocol};
+use pallet_ibc::{
+	ics20_fee::NonFlatFeeConverter, light_client_common::RelayChain, LightClientProtocol,
+};
 use smallvec::smallvec;
 use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
@@ -703,6 +705,9 @@ parameter_types! {
 	pub const IbcTriePrefix : &'static [u8] = b"ibc/";
 	pub FeeAccount: <Runtime as pallet_ibc::Config>::AccountIdConversion = create_alice_key();
 	pub const CleanUpPacketsPeriod: BlockNumber = 100;
+	pub AssetIdUSDT: AssetId = 0;
+	pub FlatFeeUSDTAmount: Balance = 0;
+	pub IbcIcs20ServiceCharge: Perbill = Perbill::from_rational(4_u32, 1000_u32 );
 }
 
 fn create_alice_key() -> <Runtime as pallet_ibc::Config>::AccountIdConversion {
@@ -742,6 +747,10 @@ impl pallet_ibc::Config for Runtime {
 	type Ics20RateLimiter = Everything;
 	type FeeAccount = FeeAccount;
 	type CleanUpPacketsPeriod = CleanUpPacketsPeriod;
+	type ServiceChargeOut = IbcIcs20ServiceCharge;
+	type FlatFeeConverter = NonFlatFeeConverter<Runtime>;
+	type FlatFeeAssetId = AssetIdUSDT;
+	type FlatFeeAmount = FlatFeeUSDTAmount;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.


### PR DESCRIPTION
This PR added functionality to charge during transfer extrinsic before IBC execution on source/sender chain with flat/percentage fee and only not whitelisted channels.

List of changes:

1. Transfer extrinsic in ibc pallet do extra staff:
- check two channels end in white list storage map
- calculate the fee or flat fee depends on the configuration of` pallet-ibc`
- send fee to fee account configured in pallet Config as `FeeAccount`.
- modify `packet data` to reduce amount of coin that will be transferred via IBC
- store into Storage map new entity : `key` ->  pre-calculated sequence `get_next_sequence_send`, `value` -> calculated fee.

2. `on_acknowledgement_packet` callback contains extra logic:
- on success acknowledgement remove storage value by sequence key. 
- on failure acknowledgement refund fee back (find fee by sequence, transfer fee from fee account to refund account address)

3. `on_timeout_packet` callback contains extra logic:
- refund fee back (find fee by sequence, transfer fee from fee account to refund account address)

4. IBC pallet contains two extra extrisnics:
- `add_channels_to_free_fee_whitelist`
- `remove_channels_from_free_fee_whitelist`


This PR also introduced whitelist mechanism via StorageMap for zero fee when token delivered via IBC.
