### PR TITLE
Disable skipping client updates for tendermint

### DIFF
--- a/hyperspace/cosmos/src/client.rs
+++ b/hyperspace/cosmos/src/client.rs
@@ -398,7 +398,7 @@ where
 						&latest_light_block.validators,
 						&latest_light_block.next_validators,
 					) {
-						true => UpdateType::Optional,
+						true => UpdateType::Mandatory,
 						false => UpdateType::Mandatory,
 					};
 					Ok((


### PR DESCRIPTION
Sometimes an IBC message expects client/consensus states to exist for height that wasn't submitted because of a non-mandatory update. This is probably an issue on the relayer side, but since it will take time to investigate and fix it, it's better to just disable this feature for now 