### PR TITLE
Update hyperspace docs how to run the tests

### DIFF
--- a/hyperspace/testsuite/README.md
+++ b/hyperspace/testsuite/README.md
@@ -93,5 +93,16 @@ Using the testsuite is straight forward and the following pseudocode describes t
 ## Running parachain tests
 
 To run the integration tests between two parachain nodes:
-1. Spawn the parachain and relay chain cluster by running [`docker-compose.yml`](/scripts/parachain-launch/docker-compose.yml`)
-2. Run the tests with `cargo test -p hyperspace-testsuite`.  
+
+1. clone polkadot (branch release-v0.9.x) clone into the parent folder for centauri
+   `git clone https://github.com/paritytech/polkadot`
+2. Build branch release-v0.9.x `cargo build -r --bin polkadot`
+3. build parachain-node in release `cargo build -r --bin parachain-node`
+4. run script:
+   - navigate to scripts folder in centauri repo: `cd scripts/polkadot-launch`
+   - `yarn install`
+   - `yarn dev`
+5. optional: regenerate subxt types [`more detailed instruction`](../../utils/subxt/codegen/README.md)
+   `cargo run --release -p codegen --bin codegen -- --path ./utils/subxt/generated/src/default`
+6. run the test
+   `cargo +nightly test -p hyperspace-testsuite --locked --release`

--- a/hyperspace/testsuite/README.md
+++ b/hyperspace/testsuite/README.md
@@ -103,6 +103,6 @@ To run the integration tests between two parachain nodes:
    - `yarn install`
    - `yarn dev`
 5. optional: regenerate subxt types [`more detailed instruction`](../../utils/subxt/codegen/README.md)
-   `cargo run --release -p codegen --bin codegen -- --path ./utils/subxt/generated/src/default`
+   `cargo run --bin codegen -- --path ./utils/subxt/generated/src/default`
 6. run the test
-   `cargo +nightly test -p hyperspace-testsuite --locked --release`
+   `cargo test -p hyperspace-testsuite`


### PR DESCRIPTION
- hyperspace/testsuite/README.md updated
- provided the detailed up to date instruction how to run IBC integration tests with two parachains.