### PR TITLE
Fix build that broken by PushWasmCode

### DIFF
--- a/hyperspace/core/src/substrate/default.rs
+++ b/hyperspace/core/src/substrate/default.rs
@@ -131,10 +131,7 @@ define_runtime_transactions!(
 	)
 );
 
-define_ibc_event_wrapper!(
-	IbcEventWrapper,
-	MetadataIbcEvent,
-);
+define_ibc_event_wrapper!(IbcEventWrapper, MetadataIbcEvent,);
 
 define_event_record!(
 	DefaultEventRecord,

--- a/hyperspace/core/src/substrate/default.rs
+++ b/hyperspace/core/src/substrate/default.rs
@@ -134,7 +134,6 @@ define_runtime_transactions!(
 define_ibc_event_wrapper!(
 	IbcEventWrapper,
 	MetadataIbcEvent,
-	MetadataIbcEvent::PushWasmCode { wasm_code_id } => RawIbcEvent::PushWasmCode { wasm_code_id },
 );
 
 define_event_record!(

--- a/hyperspace/core/src/substrate/macros.rs
+++ b/hyperspace/core/src/substrate/macros.rs
@@ -487,6 +487,9 @@ macro_rules! define_ibc_event_wrapper {
 						RawIbcEvent::AppModule { kind, module_id },
 					MetadataIbcEvent::Empty => RawIbcEvent::Empty,
 					MetadataIbcEvent::ChainError => RawIbcEvent::ChainError,
+					MetadataIbcEvent::PushWasmCode{ wasm_code_id } => RawIbcEvent::PushWasmCode {
+						wasm_code_id
+					},
 					$($additional)*
 				}
 			}

--- a/hyperspace/core/src/substrate/picasso_kusama.rs
+++ b/hyperspace/core/src/substrate/picasso_kusama.rs
@@ -137,7 +137,6 @@ define_runtime_transactions!(
 define_ibc_event_wrapper!(
 	IbcEventWrapper,
 	MetadataIbcEvent,
-	MetadataIbcEvent::PushWasmCode { wasm_code_id } => RawIbcEvent::PushWasmCode { wasm_code_id },
 );
 
 define_event_record!(

--- a/hyperspace/core/src/substrate/picasso_kusama.rs
+++ b/hyperspace/core/src/substrate/picasso_kusama.rs
@@ -134,10 +134,7 @@ define_runtime_transactions!(
 	|| unimplemented("ibc_increase_counters is not implemented")
 );
 
-define_ibc_event_wrapper!(
-	IbcEventWrapper,
-	MetadataIbcEvent,
-);
+define_ibc_event_wrapper!(IbcEventWrapper, MetadataIbcEvent,);
 
 define_event_record!(
 	PicassoEventRecord,

--- a/utils/subxt/generated/src/composable/parachain.rs
+++ b/utils/subxt/generated/src/composable/parachain.rs
@@ -22019,6 +22019,10 @@ pub mod api {
 						kind: ::std::vec::Vec<::core::primitive::u8>,
 						module_id: ::std::vec::Vec<::core::primitive::u8>,
 					},
+					#[codec(index = 24)]
+					PushWasmCode {
+						wasm_code_id: ::std::vec::Vec<::core::primitive::u8>,
+					},
 				}
 			}
 			pub mod ics20_fee {

--- a/utils/subxt/generated/src/composable/parachain.rs
+++ b/utils/subxt/generated/src/composable/parachain.rs
@@ -22020,9 +22020,7 @@ pub mod api {
 						module_id: ::std::vec::Vec<::core::primitive::u8>,
 					},
 					#[codec(index = 24)]
-					PushWasmCode {
-						wasm_code_id: ::std::vec::Vec<::core::primitive::u8>,
-					},
+					PushWasmCode { wasm_code_id: ::std::vec::Vec<::core::primitive::u8> },
 				}
 			}
 			pub mod ics20_fee {

--- a/utils/subxt/generated/src/picasso_kusama/parachain.rs
+++ b/utils/subxt/generated/src/picasso_kusama/parachain.rs
@@ -25680,6 +25680,10 @@ pub mod api {
 						kind: ::std::vec::Vec<::core::primitive::u8>,
 						module_id: ::std::vec::Vec<::core::primitive::u8>,
 					},
+					#[codec(index = 24)]
+					PushWasmCode {
+						wasm_code_id: ::std::vec::Vec<::core::primitive::u8>,
+					},
 				}
 			}
 			pub mod ics20_fee {

--- a/utils/subxt/generated/src/picasso_kusama/parachain.rs
+++ b/utils/subxt/generated/src/picasso_kusama/parachain.rs
@@ -25681,9 +25681,7 @@ pub mod api {
 						module_id: ::std::vec::Vec<::core::primitive::u8>,
 					},
 					#[codec(index = 24)]
-					PushWasmCode {
-						wasm_code_id: ::std::vec::Vec<::core::primitive::u8>,
-					},
+					PushWasmCode { wasm_code_id: ::std::vec::Vec<::core::primitive::u8> },
 				}
 			}
 			pub mod ics20_fee {

--- a/utils/subxt/generated/src/picasso_rococo/parachain.rs
+++ b/utils/subxt/generated/src/picasso_rococo/parachain.rs
@@ -25680,6 +25680,10 @@ pub mod api {
 						kind: ::std::vec::Vec<::core::primitive::u8>,
 						module_id: ::std::vec::Vec<::core::primitive::u8>,
 					},
+					#[codec(index = 24)]
+					PushWasmCode {
+						wasm_code_id: ::std::vec::Vec<::core::primitive::u8>,
+					},
 				}
 			}
 			pub mod ics20_fee {

--- a/utils/subxt/generated/src/picasso_rococo/parachain.rs
+++ b/utils/subxt/generated/src/picasso_rococo/parachain.rs
@@ -25681,9 +25681,7 @@ pub mod api {
 						module_id: ::std::vec::Vec<::core::primitive::u8>,
 					},
 					#[codec(index = 24)]
-					PushWasmCode {
-						wasm_code_id: ::std::vec::Vec<::core::primitive::u8>,
-					},
+					PushWasmCode { wasm_code_id: ::std::vec::Vec<::core::primitive::u8> },
 				}
 			}
 			pub mod ics20_fee {


### PR DESCRIPTION
add extra event into IBC Event
```
#[codec(index = 24)]
	PushWasmCode {
		wasm_code_id: ::std::vec::Vec<::core::primitive::u8>,
},
```
into generated subxt parachain for composable/kusama/rococo-picasso
