### PR TITLE
Remove Bob from collator selection to fix block time from 24sec to 12sec

### DIFF
--- a/hyperspace/core/src/lib.rs
+++ b/hyperspace/core/src/lib.rs
@@ -53,38 +53,6 @@ where
 	let (mut chain_a_finality, mut chain_b_finality) =
 		(chain_a.finality_notifications().await?, chain_b.finality_notifications().await?);
 
-	// If light clients on both chains are not synced then send the old updates and events before
-	// listening for new events
-	if !chain_a.is_synced(&chain_b).await? {
-		let (mut messages, events) = chain_a.fetch_mandatory_updates(&chain_b).await?;
-		// we use light mode because channel state will be queried during the full relay operation
-		let parsed_messages =
-			parse_events(&mut chain_a, &mut chain_b, events, Some(Mode::Light)).await?;
-		messages.extend(parsed_messages);
-		log::info!(target: "hyperspace",
-			"Syncing Chain {}'s light client on chain {} {:#?}",
-			chain_a.name(),
-				chain_b.name(),
-			messages.iter().map(|msg| &msg.type_url).collect::<Vec<_>>()
-		);
-		queue::flush_message_batch(messages, chain_a_metrics.as_ref(), &chain_b).await?;
-	}
-
-	if !chain_b.is_synced(&chain_a).await? {
-		let (mut messages, events) = chain_b.fetch_mandatory_updates(&chain_a).await?;
-		// we use light mode because channel state will be queried during the full relay operation
-		let parsed_messages =
-			parse_events(&mut chain_b, &mut chain_a, events, Some(Mode::Light)).await?;
-		messages.extend(parsed_messages);
-		log::info!(target: "hyperspace",
-			"Syncing Chain {}'s light client on chain {} {:#?}",
-			chain_b.name(),
-				chain_a.name(),
-			messages.iter().map(|msg| &msg.type_url).collect::<Vec<_>>()
-		);
-		queue::flush_message_batch(messages, chain_b_metrics.as_ref(), &chain_a).await?;
-	}
-
 	// loop forever
 	loop {
 		tokio::select! {

--- a/hyperspace/primitives/src/utils.rs
+++ b/hyperspace/primitives/src/utils.rs
@@ -186,7 +186,7 @@ pub async fn create_channel(
 
 	let mut events = timeout_future(
 		future,
-		15 * 60,
+		30 * 60,
 		format!("Didn't see OpenConfirmChannel on {}", chain_b.name()),
 	)
 	.await;

--- a/utils/parachain-node/src/chain_spec.rs
+++ b/utils/parachain-node/src/chain_spec.rs
@@ -96,10 +96,6 @@ pub fn development_config(para_id: u32) -> ChainSpec {
 						get_account_id_from_seed::<sr25519::Public>("Alice"),
 						get_collator_keys_from_seed("Alice"),
 					),
-					(
-						get_account_id_from_seed::<sr25519::Public>("Bob"),
-						get_collator_keys_from_seed("Bob"),
-					),
 				],
 				vec![
 					get_account_id_from_seed::<sr25519::Public>("Alice"),
@@ -150,10 +146,6 @@ pub fn local_testnet_config() -> ChainSpec {
 					(
 						get_account_id_from_seed::<sr25519::Public>("Alice"),
 						get_collator_keys_from_seed("Alice"),
-					),
-					(
-						get_account_id_from_seed::<sr25519::Public>("Bob"),
-						get_collator_keys_from_seed("Bob"),
 					),
 				],
 				vec![

--- a/utils/parachain-node/src/chain_spec.rs
+++ b/utils/parachain-node/src/chain_spec.rs
@@ -91,12 +91,10 @@ pub fn development_config(para_id: u32) -> ChainSpec {
 		move || {
 			testnet_genesis(
 				// initial collators.
-				vec![
-					(
-						get_account_id_from_seed::<sr25519::Public>("Alice"),
-						get_collator_keys_from_seed("Alice"),
-					),
-				],
+				vec![(
+					get_account_id_from_seed::<sr25519::Public>("Alice"),
+					get_collator_keys_from_seed("Alice"),
+				)],
 				vec![
 					get_account_id_from_seed::<sr25519::Public>("Alice"),
 					get_account_id_from_seed::<sr25519::Public>("Bob"),
@@ -142,12 +140,10 @@ pub fn local_testnet_config() -> ChainSpec {
 		move || {
 			testnet_genesis(
 				// initial collators.
-				vec![
-					(
-						get_account_id_from_seed::<sr25519::Public>("Alice"),
-						get_collator_keys_from_seed("Alice"),
-					),
-				],
+				vec![(
+					get_account_id_from_seed::<sr25519::Public>("Alice"),
+					get_collator_keys_from_seed("Alice"),
+				)],
 				vec![
 					get_account_id_from_seed::<sr25519::Public>("Alice"),
 					get_account_id_from_seed::<sr25519::Public>("Bob"),


### PR DESCRIPTION
This PR related to https://github.com/ComposableFi/centauri/issues/331
Integration tests has an issue with block time. **24 sec** for block instead expected **12 sec** per block.

The issue with 24 sec and 12 sec as we expected is that `testnet_geneisis` contains two collators nodes : `Alice and Bob`.
Aura provide Bob ability to produce block in his turn. but there was not Bob collator running at all.
So `Bob collator node `skipped his turn and block produced each 24 sec because only `Alice collator` is running for integration tests.