### PR TITLE
chore: update rust toolchain to nightly-2022-12-31

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly-2022-12-31"
+targets = [ "wasm32-unknown-unknown"]
+profile = "minimal"


### PR DESCRIPTION
The para chain isn't running on the end to end testing due to a compiler version issue. This is probably due to the fact that parity docker image uses the wrong version of the Rust compiler. Therefore, we are forcing the version on the toolchain file.