### PR TITLE
Simplify account_id_to_ss58 by preserving return type

### DIFF
--- a/contracts/pallet-ibc/primitives/src/runtime_interface.rs
+++ b/contracts/pallet-ibc/primitives/src/runtime_interface.rs
@@ -67,10 +67,10 @@ pub fn ss58_to_account_id_32(raw_str: &str) -> Result<[u8; 32], SS58CodecError> 
 		.map_err(|_| SS58CodecError::InvalidString)
 }
 
-pub fn account_id_to_ss58(bytes: [u8; 32], version: u16) -> Vec<u8> {
+#[inline(always)]
+pub fn account_id_to_ss58(bytes: [u8; 32], version: u16) -> String {
 	let account_id = AccountId32::new(bytes);
-	let encoded = to_ss58check_with_version(account_id, version);
-	encoded.as_bytes().to_vec()
+	to_ss58check_with_version(account_id, version)
 }
 
 // lifted directly from sp-core
@@ -174,7 +174,7 @@ mod tests {
 		let alice = "5yNZjX24n2eg7W6EVamaTXNQbWCwchhThEaSWB7V3GRjtHeL";
 		let account_id = ss58_to_account_id_32(alice).unwrap();
 		let ss58_account = account_id_to_ss58(account_id.into(), 49);
-		assert_eq!(alice, String::from_utf8(ss58_account).unwrap());
+		assert_eq!(alice, ss58_account);
 	}
 
 	#[test]

--- a/contracts/pallet-ibc/src/impls.rs
+++ b/contracts/pallet-ibc/src/impls.rs
@@ -987,9 +987,6 @@ where
 			account_id_32.into(),
 			<T as frame_system::Config>::SS58Prefix::get(),
 		);
-		let from = String::from_utf8(from).map_err(|_| IbcHandlerError::SendTransferError {
-			msg: Some("Account Id conversion failed".to_string()),
-		})?;
 		let (latest_height, latest_timestamp) =
 			Pallet::<T>::latest_height_and_timestamp(&PortId::transfer(), &channel_id).map_err(
 				|_| IbcHandlerError::TimestampOrHeightNotFound {

--- a/contracts/pallet-ibc/src/tests.rs
+++ b/contracts/pallet-ibc/src/tests.rs
@@ -211,8 +211,8 @@ fn send_transfer() {
 	let balance = 100000 * MILLIS;
 	ext.execute_with(|| {
 		let pair = sp_core::sr25519::Pair::from_seed(b"12345678901234567890123456789012");
-		let raw_user = ibc_primitives::runtime_interface::account_id_to_ss58(pair.public().0, 49);
-		let ss58_address = String::from_utf8(raw_user).unwrap();
+		let ss58_address =
+			ibc_primitives::runtime_interface::account_id_to_ss58(pair.public().0, 49);
 		setup_client_and_consensus_state(PortId::transfer());
 		let asset_id =
 			<<Test as Config>::IbcDenomToAssetIdConversion as DenomToAssetId<Test>>::from_denom_to_asset_id(
@@ -268,8 +268,8 @@ fn send_transfer_no_fee_feeless_channels() {
 	let balance = 100000 * MILLIS;
 	ext.execute_with(|| {
 		let pair = sp_core::sr25519::Pair::from_seed(b"12345678901234567890123456789012");
-		let raw_user = ibc_primitives::runtime_interface::account_id_to_ss58(pair.public().0, 49);
-		let ss58_address = String::from_utf8(raw_user).unwrap();
+		let ss58_address =
+			ibc_primitives::runtime_interface::account_id_to_ss58(pair.public().0, 49);
 		setup_client_and_consensus_state(PortId::transfer());
 		let asset_id =
 			<<Test as Config>::IbcDenomToAssetIdConversion as DenomToAssetId<Test>>::from_denom_to_asset_id(
@@ -337,9 +337,8 @@ fn on_deliver_ics20_recv_packet() {
 	ext.execute_with(|| {
 		// Create  a new account
 		let pair = sp_core::sr25519::Pair::from_seed(b"12345678901234567890123456789012");
-		let ss58_address_bytes =
+		let ss58_address =
 			ibc_primitives::runtime_interface::account_id_to_ss58(pair.public().0, 49);
-		let ss58_address = String::from_utf8(ss58_address_bytes).unwrap();
 		frame_system::Pallet::<Test>::set_block_number(1u32);
 		let asset_id =
 			<<Test as Config>::IbcDenomToAssetIdConversion as DenomToAssetId<Test>>::from_denom_to_asset_id(
@@ -436,9 +435,8 @@ fn on_deliver_ics20_recv_packet_with_flat_fee() {
 	ext.execute_with(|| {
 		// Create  a new account
 		let pair = sp_core::sr25519::Pair::from_seed(b"12345678901234567890123456789012");
-		let ss58_address_bytes =
+		let ss58_address =
 			ibc_primitives::runtime_interface::account_id_to_ss58(pair.public().0, 49);
-		let ss58_address = String::from_utf8(ss58_address_bytes).unwrap();
 		frame_system::Pallet::<Test>::set_block_number(1u32);
 		let asset_id =
 			<<Test as Config>::IbcDenomToAssetIdConversion as DenomToAssetId<Test>>::from_denom_to_asset_id(
@@ -537,9 +535,8 @@ fn on_deliver_ics20_recv_packet_transfered_amount_less_then_flat_fee() {
 	ext.execute_with(|| {
 		// Create  a new account
 		let pair = sp_core::sr25519::Pair::from_seed(b"12345678901234567890123456789012");
-		let ss58_address_bytes =
+		let ss58_address =
 			ibc_primitives::runtime_interface::account_id_to_ss58(pair.public().0, 49);
-		let ss58_address = String::from_utf8(ss58_address_bytes).unwrap();
 		frame_system::Pallet::<Test>::set_block_number(1u32);
 		let asset_id =
 			<<Test as Config>::IbcDenomToAssetIdConversion as DenomToAssetId<Test>>::from_denom_to_asset_id(
@@ -649,9 +646,8 @@ fn on_deliver_ics20_recv_packet_should_not_double_spend() {
 	ext.execute_with(|| {
 		// Create  a new account
 		let pair = sp_core::sr25519::Pair::from_seed(b"12345678901234567890123456789012");
-		let ss58_address_bytes =
+		let ss58_address =
 			ibc_primitives::runtime_interface::account_id_to_ss58(pair.public().0, 49);
-		let ss58_address = String::from_utf8(ss58_address_bytes).unwrap();
 		frame_system::Pallet::<Test>::set_block_number(1u32);
 		setup_client_and_consensus_state(PortId::transfer());
 


### PR DESCRIPTION
By returning `Vec<u8>` rather than `String`, account_id_to_ss58 discards information about the returned value, namely about the fact that it’s valid UTF-8 string.  This forces clients to either use unsafe code or perform UTF-8 validation and dealing with an error case (which in practice is dead code).

Change account_id_to_ss58 to return `String` and thus preserving more information about the value.  Clients who wish to operate on `Vec<u8>` can use `String::into_bytes` to get it.