### PR TITLE
Fixes and improvements for queries 

### DIFF
--- a/.github/workflows/hyperspace-docker-image.yml
+++ b/.github/workflows/hyperspace-docker-image.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - vmarkushin/optimize-queries
 
 jobs:
   build-and-publish:

--- a/.github/workflows/hyperspace-docker-image.yml
+++ b/.github/workflows/hyperspace-docker-image.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - vmarkushin/optimize-queries
 
 jobs:
   build-and-publish:

--- a/hyperspace/core/src/macros.rs
+++ b/hyperspace/core/src/macros.rs
@@ -410,7 +410,7 @@ macro_rules! chains {
 				}
 			}
 
-			async fn query_recv_packets(
+			async fn query_received_packets(
 				&self,
 				channel_id: ChannelId,
 				port_id: PortId,
@@ -420,11 +420,11 @@ macro_rules! chains {
 					$(
 						$(#[$($meta)*])*
 						Self::$name(chain) => chain
-							.query_recv_packets(channel_id, port_id, seqs)
+							.query_received_packets(channel_id, port_id, seqs)
 							.await
 							.map_err(AnyError::$name),
 					)*
-					Self::Wasm(c) => c.inner.query_recv_packets(channel_id, port_id, seqs).await,
+					Self::Wasm(c) => c.inner.query_received_packets(channel_id, port_id, seqs).await,
 				}
 			}
 

--- a/hyperspace/core/src/packets.rs
+++ b/hyperspace/core/src/packets.rs
@@ -394,6 +394,7 @@ pub async fn query_ready_and_timed_out_packets(
 		)
 		.await?
 		.into_iter()
+		.take(max_packets_to_process)
 		.collect::<Vec<_>>();
 
 		let acknowledgements =

--- a/hyperspace/core/src/packets.rs
+++ b/hyperspace/core/src/packets.rs
@@ -396,7 +396,8 @@ pub async fn query_ready_and_timed_out_packets(
 		.into_iter()
 		.collect::<Vec<_>>();
 
-		let acknowledgements = source.query_recv_packets(channel_id, port_id.clone(), acks).await?;
+		let acknowledgements =
+			source.query_received_packets(channel_id, port_id.clone(), acks).await?;
 		log::trace!(target: "hyperspace", "Got acknowledgements for channel {:?}: {:?}", channel_id, acknowledgements);
 		let mut acknowledgements_join_set: JoinSet<Result<_, anyhow::Error>> = JoinSet::new();
 		sink.on_undelivered_sequences(!acknowledgements.is_empty(), UndeliveredType::Acks)

--- a/hyperspace/cosmos/src/client.rs
+++ b/hyperspace/cosmos/src/client.rs
@@ -301,7 +301,7 @@ where
 				maybe_has_undelivered_packets: Default::default(),
 				rpc_call_delay: Duration::from_millis(1000),
 				misbehaviour_client_msg_queue: Arc::new(AsyncMutex::new(vec![])),
-				max_packets_to_process: 50,
+				max_packets_to_process: config.common.max_packets_to_process as usize,
 			},
 			join_handles: Arc::new(TokioMutex::new(vec![ws_driver_jh])),
 		})

--- a/hyperspace/cosmos/src/client.rs
+++ b/hyperspace/cosmos/src/client.rs
@@ -43,7 +43,7 @@ use std::{
 use tendermint::{block::Height as TmHeight, Hash};
 use tendermint_light_client::components::io::{AtHeight, Io};
 use tendermint_light_client_verifier::types::{LightBlock, ValidatorSet};
-use tendermint_rpc::{endpoint::abci_query::AbciQuery, Client, Url, WebSocketClient};
+use tendermint_rpc::{endpoint::abci_query::AbciQuery, Client, HttpClient, Url, WebSocketClient};
 use tokio::{
 	sync::{Mutex as TokioMutex, Mutex as AsyncMutex},
 	task::{JoinHandle, JoinSet},

--- a/hyperspace/cosmos/src/client.rs
+++ b/hyperspace/cosmos/src/client.rs
@@ -131,6 +131,8 @@ pub struct CosmosClient<H> {
 	pub name: String,
 	/// Chain rpc client
 	pub rpc_client: WebSocketClient,
+	/// Chain http rpc client
+	pub rpc_http_client: HttpClient,
 	/// Reusable GRPC client
 	pub grpc_client: tonic::transport::Channel,
 	/// Chain rpc address
@@ -250,6 +252,8 @@ where
 		let (rpc_client, rpc_driver) = WebSocketClient::new(config.websocket_url.clone())
 			.await
 			.map_err(|e| Error::RpcError(format!("{:?}", e)))?;
+		let rpc_http_client = HttpClient::new(config.rpc_url.clone())
+			.map_err(|e| Error::RpcError(format!("{:?}", e)))?;
 		let ws_driver_jh = tokio::spawn(rpc_driver.run());
 		let grpc_client = tonic::transport::Endpoint::new(config.grpc_url.to_string())
 			.map_err(|e| Error::RpcError(format!("{:?}", e)))?
@@ -273,6 +277,7 @@ where
 			name: config.name,
 			chain_id,
 			rpc_client,
+			rpc_http_client,
 			grpc_client,
 			rpc_url: config.rpc_url,
 			grpc_url: config.grpc_url,
@@ -485,8 +490,8 @@ where
 
 		// Use the Tendermint-rs RPC client to do the query.
 		let response = self
-			.rpc_client
-			.abci_query(Some(path.to_owned()), data, height, prove)
+			.rpc_http_client
+			.abci_query(Some(path.to_owned()), data.clone(), height, prove)
 			.await
 			.map_err(|e| {
 				Error::from(format!("Failed to query chain {} with error {:?}", self.name, e))

--- a/hyperspace/cosmos/src/provider.rs
+++ b/hyperspace/cosmos/src/provider.rs
@@ -788,7 +788,8 @@ where
 	}
 
 	fn expected_block_time(&self) -> Duration {
-		Duration::from_secs(30)
+		// cosmos chain block time is roughly 6-7 seconds
+		Duration::from_secs(7)
 	}
 
 	async fn query_client_update_time_and_height(
@@ -1369,6 +1370,7 @@ where
 						"message",
 						"liveness",
 						"tx",
+						"fungible_token_packet",
 					];
 					if !ignored_events.contains(&event.kind.as_str()) {
 						log::debug!(target: "hyperspace_cosmos", "Skipped event: {:?}", event.kind);

--- a/hyperspace/cosmos/src/provider.rs
+++ b/hyperspace/cosmos/src/provider.rs
@@ -737,9 +737,11 @@ where
 			if added_seqs.contains(&seq) {
 				continue
 			}
-			let query_str = Query::eq("recv_packet.packet_dst_channel", channel_id.to_string())
-				.and_eq("recv_packet.packet_dst_port", port_id.to_string())
-				.and_eq("recv_packet.packet_sequence", seq.to_string());
+
+			let query_str =
+				Query::eq("write_acknowledgement.packet_dst_channel", channel_id.to_string())
+					.and_eq("write_acknowledgement.packet_dst_port", port_id.to_string())
+					.and_eq("write_acknowledgement.packet_sequence", seq.to_string());
 
 			let response = self
 				.rpc_http_client

--- a/hyperspace/cosmos/src/provider.rs
+++ b/hyperspace/cosmos/src/provider.rs
@@ -677,7 +677,7 @@ where
 				.and_eq("send_packet.packet_sequence", seq.to_string());
 
 			let response = self
-				.rpc_client
+				.rpc_http_client
 				.tx_search(
 					query_str,
 					true,
@@ -742,7 +742,7 @@ where
 				.and_eq("recv_packet.packet_sequence", seq.to_string());
 
 			let response = self
-				.rpc_client
+				.rpc_http_client
 				.tx_search(
 					query_str,
 					true,
@@ -800,10 +800,11 @@ where
 			client_id,
 			client_height
 		);
-		let query_str = Query::eq("update_client.client_id", client_id.to_string());
+		let query_str = Query::eq("update_client.client_id", client_id.to_string())
+			.and_eq("update_client.consensus_height", client_height.to_string());
 
 		let response = self
-			.rpc_client
+			.rpc_http_client
 			.tx_search(
 				query_str,
 				true,

--- a/hyperspace/cosmos/src/provider.rs
+++ b/hyperspace/cosmos/src/provider.rs
@@ -719,7 +719,7 @@ where
 		Ok(block_events)
 	}
 
-	async fn query_recv_packets(
+	async fn query_received_packets(
 		&self,
 		channel_id: ChannelId,
 		port_id: PortId,

--- a/hyperspace/cosmos/src/provider.rs
+++ b/hyperspace/cosmos/src/provider.rs
@@ -1311,13 +1311,13 @@ where
 	) -> Result<Vec<IbcEvent>, <Self as IbcProvider>::Error> {
 		let mut ibc_events = Vec::new();
 
-		let block_results =
-			self.rpc_client.block_results(TmHeight::try_from(height)?).await.map_err(|e| {
-				Error::from(format!(
-					"Failed to query block result for height {:?}: {:?}",
-					height, e
-				))
-			})?;
+		let block_results = self
+			.rpc_http_client
+			.block_results(TmHeight::try_from(height)?)
+			.await
+			.map_err(|e| {
+			Error::from(format!("Failed to query block result for height {:?}: {:?}", height, e))
+		})?;
 
 		let tx_events = block_results
 			.txs_results
@@ -1391,7 +1391,7 @@ impl<H: Clone + Send + Sync + 'static> CosmosClient<H> {
 
 		let response: Response = loop {
 			let response = self
-				.rpc_client
+				.rpc_http_client
 				.tx_search(
 					Query::eq("tx.hash", tx_id.hash.to_string()),
 					false,

--- a/hyperspace/parachain/src/chain.rs
+++ b/hyperspace/parachain/src/chain.rs
@@ -104,7 +104,7 @@ where
 	}
 
 	fn block_max_weight(&self) -> u64 {
-		self.max_extrinsic_weight
+		self.max_extrinsic_weight * 100 / 80
 	}
 
 	async fn estimate_weight(&self, messages: Vec<Any>) -> Result<u64, Self::Error> {

--- a/hyperspace/parachain/src/provider.rs
+++ b/hyperspace/parachain/src/provider.rs
@@ -487,7 +487,7 @@ where
 		Ok(response)
 	}
 
-	async fn query_recv_packets(
+	async fn query_received_packets(
 		&self,
 		channel_id: ChannelId,
 		port_id: PortId,

--- a/hyperspace/primitives/src/lib.rs
+++ b/hyperspace/primitives/src/lib.rs
@@ -348,7 +348,7 @@ pub trait IbcProvider {
 	/// Query received packets with their acknowledgement
 	/// This represents packets for which the `ReceivePacket` and `WriteAcknowledgement` events were
 	/// emitted.
-	async fn query_recv_packets(
+	async fn query_received_packets(
 		&self,
 		channel_id: ChannelId,
 		port_id: PortId,

--- a/hyperspace/primitives/src/lib.rs
+++ b/hyperspace/primitives/src/lib.rs
@@ -722,16 +722,13 @@ pub async fn find_suitable_proof_height_for_client(
 				continue
 			}
 			let proof_height = source.get_proof_height(temp_height).await;
-			if proof_height != temp_height {
-				let has_consensus_state_with_proof = sink
-					.query_client_consensus(at, client_id.clone(), proof_height)
-					.await
-					.ok()
-					.map(|x| x.consensus_state.is_some())
-					.unwrap_or_default();
-				if !has_consensus_state_with_proof {
-					continue
-				}
+			let has_client_state = sink
+				.query_client_update_time_and_height(client_id.clone(), proof_height)
+				.await
+				.ok()
+				.is_some();
+			if !has_client_state {
+				continue
 			}
 			log::info!("Found proof height on {} as {}:{}", sink.name(), temp_height, proof_height);
 			return Some(temp_height)
@@ -759,17 +756,14 @@ pub async fn find_suitable_proof_height_for_client(
 				continue
 			};
 			let proof_height = source.get_proof_height(temp_height).await;
-			if proof_height != temp_height {
-				let has_consensus_state_with_proof = sink
-					.query_client_consensus(at, client_id.clone(), proof_height)
-					.await
-					.ok()
-					.map(|x| x.consensus_state.is_some())
-					.unwrap_or_default();
-				if !has_consensus_state_with_proof {
-					start += 1;
-					continue
-				}
+			let has_client_state = sink
+				.query_client_update_time_and_height(client_id.clone(), proof_height)
+				.await
+				.ok()
+				.is_some();
+			if !has_client_state {
+				start += 1;
+				continue
 			}
 
 			if consensus_state.timestamp().nanoseconds() < timestamp_to_match.nanoseconds() {
@@ -790,17 +784,12 @@ pub async fn find_suitable_proof_height_for_client(
 		{
 			if consensus_state.timestamp().nanoseconds() >= timestamp_to_match.nanoseconds() {
 				let proof_height = source.get_proof_height(start_height).await;
-				if proof_height != start_height {
-					let has_consensus_state_with_proof = sink
-						.query_client_consensus(at, client_id.clone(), proof_height)
-						.await
-						.ok()
-						.map(|x| x.consensus_state.is_some())
-						.unwrap_or_default();
-					if has_consensus_state_with_proof {
-						return Some(start_height)
-					}
-				} else {
+				let has_client_state = sink
+					.query_client_update_time_and_height(client_id.clone(), proof_height)
+					.await
+					.ok()
+					.is_some();
+				if has_client_state {
 					return Some(start_height)
 				}
 			}

--- a/hyperspace/primitives/src/lib.rs
+++ b/hyperspace/primitives/src/lib.rs
@@ -99,6 +99,10 @@ fn default_skip_optional_client_updates() -> bool {
 	true
 }
 
+fn max_packets_to_process() -> u32 {
+	50
+}
+
 // TODO: move other fields like `client_id`, `connection_id`, etc. here
 /// Common relayer parameters
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -106,6 +110,8 @@ pub struct CommonClientConfig {
 	/// Skip optional client updates
 	#[serde(default = "default_skip_optional_client_updates")]
 	pub skip_optional_client_updates: bool,
+	#[serde(default = "max_packets_to_process")]
+	pub max_packets_to_process: u32,
 }
 
 /// A common data that all clients should keep.

--- a/hyperspace/testsuite/tests/parachain_cosmos.rs
+++ b/hyperspace/testsuite/tests/parachain_cosmos.rs
@@ -112,7 +112,10 @@ async fn setup_clients() -> (AnyChain, AnyChain) {
 				.to_string(),
 		wasm_code_id: None,
 		channel_whitelist: vec![],
-		common: CommonClientConfig { skip_optional_client_updates: true },
+		common: CommonClientConfig {
+			skip_optional_client_updates: true,
+			max_packets_to_process: 200,
+		},
 	};
 
 	let chain_b = CosmosClient::<DefaultConfig>::new(config_b.clone()).await.unwrap();


### PR DESCRIPTION
- Ues HttpClient for some queries . `HttpClient` is more stable in some cases than `WebsocketClient` for a cosmos node
- make max_packets_to_process a config param
- make find proof function check that client states exist
- limit undelivered packets process at once
- change expected block time for cosmos