### PR TITLE
Fix resetting RPC delay

### DIFF
--- a/hyperspace/core/src/lib.rs
+++ b/hyperspace/core/src/lib.rs
@@ -178,14 +178,14 @@ async fn process_finality_event<A: Chain, B: Chain>(
 		Some(finality_event) => {
 			log::info!("=======================================================");
 			log::info!("Received finality notification from {}", source.name(),);
-			let sink_initial_rpc_call_delay = sink.rpc_call_delay();
-			let source_initial_rpc_call_delay = source.rpc_call_delay();
 
 			let result =
 				process_some_finality_event(source, sink, metrics, mode, finality_event).await;
 
 			match result {
 				Ok(()) => {
+					let sink_initial_rpc_call_delay = sink.initial_rpc_call_delay();
+					let source_initial_rpc_call_delay = source.initial_rpc_call_delay();
 					sink.set_rpc_call_delay(sink_initial_rpc_call_delay);
 					source.set_rpc_call_delay(source_initial_rpc_call_delay);
 				},

--- a/hyperspace/cosmos/src/client.rs
+++ b/hyperspace/cosmos/src/client.rs
@@ -273,6 +273,7 @@ where
 		})
 		.map_err(|e| e.to_string())?;
 
+		let rpc_call_delay = Duration::from_millis(1000);
 		Ok(Self {
 			name: config.name,
 			chain_id,
@@ -299,7 +300,8 @@ where
 			common_state: CommonClientState {
 				skip_optional_client_updates: config.common.skip_optional_client_updates,
 				maybe_has_undelivered_packets: Default::default(),
-				rpc_call_delay: Duration::from_millis(1000),
+				rpc_call_delay,
+				initial_rpc_call_delay: rpc_call_delay,
 				misbehaviour_client_msg_queue: Arc::new(AsyncMutex::new(vec![])),
 				max_packets_to_process: config.common.max_packets_to_process as usize,
 			},

--- a/hyperspace/parachain/src/lib.rs
+++ b/hyperspace/parachain/src/lib.rs
@@ -273,6 +273,7 @@ where
 				skip_optional_client_updates: true,
 				maybe_has_undelivered_packets: Arc::new(Mutex::new(Default::default())),
 				rpc_call_delay: DEFAULT_RPC_CALL_DELAY,
+				initial_rpc_call_delay: DEFAULT_RPC_CALL_DELAY,
 				misbehaviour_client_msg_queue: Arc::new(AsyncMutex::new(vec![])),
 				..Default::default()
 			},

--- a/hyperspace/testsuite/tests/parachain_parachain.rs
+++ b/hyperspace/testsuite/tests/parachain_parachain.rs
@@ -131,7 +131,6 @@ async fn setup_clients() -> (ParachainClient<DefaultConfig>, ParachainClient<Def
 
 #[tokio::test]
 async fn parachain_to_parachain_ibc_messaging_full_integration_test() {
-	use std::time::SystemTime;
 	logging::setup_logging();
 	use hyperspace_testsuite::setup_connection_and_channel;
 	use ibc::core::ics24_host::identifier::PortId;


### PR DESCRIPTION
In case of multiple fails of RPC, the delay may increase radically and will never be reset to the initial value