### PR TITLE
chore: changed docker image for builders

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,7 +15,7 @@ jobs:
       group: lint-${{ github.ref }}
       cancel-in-progress: true
     container:
-      image: paritytech/ci-unified:latest
+      image: paritytech/ci-unified:bullseye-1.71.0
     runs-on:
       - self-hosted
       - x64-monster

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,7 +15,7 @@ jobs:
       group: lint-${{ github.ref }}
       cancel-in-progress: true
     container:
-      image: paritytech/ci-unified:bullseye-1.71.0
+      image: paritytech/ci-unified:bullseye-1.71.0-v20230727
     runs-on:
       - self-hosted
       - x64-monster

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,7 +15,7 @@ jobs:
       group: lint-${{ github.ref }}
       cancel-in-progress: true
     container:
-      image: paritytech/ci-linux:production
+      image: paritytech/ci-unified:latest
     runs-on:
       - self-hosted
       - x64-monster

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       group: check-${{ github.ref }}
       cancel-in-progress: true
     container:
-      image: paritytech/ci-unified:latest
+      image: paritytech/ci-unified:bullseye-1.71.0
     runs-on:
       - self-hosted
       - x64-monster

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       group: check-${{ github.ref }}
       cancel-in-progress: true
     container:
-      image: paritytech/ci-unified:bullseye-1.71.0
+      image: paritytech/ci-unified:bullseye-1.71.0-v20230727
     runs-on:
       - self-hosted
       - x64-monster

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       group: check-${{ github.ref }}
       cancel-in-progress: true
     container:
-      image: paritytech/ci-linux:production
+      image: paritytech/ci-unified:latest
     runs-on:
       - self-hosted
       - x64-monster

--- a/hyperspace/core/src/substrate/composable.rs
+++ b/hyperspace/core/src/substrate/composable.rs
@@ -1,7 +1,7 @@
 use self::parachain_subxt::api::{
 	ibc::calls::{Deliver, Transfer},
 	runtime_types::{
-		composable_runtime::ibc::MemoMessage,
+		// composable_runtime::ibc::MemoMessage,
 		frame_system::{extensions::check_nonce::CheckNonce, EventRecord},
 		pallet_ibc::{events::IbcEvent as MetadataIbcEvent, TransferParams as RawTransferParams},
 	},
@@ -166,7 +166,7 @@ define_runtime_transactions!(
 	TransferParamsWrapper,
 	DummySendPingParamsWrapper,
 	parachain_subxt::api::runtime_types::pallet_ibc::Any,
-	MemoMessage,
+	String,
 	|x| parachain_subxt::api::tx().ibc().deliver(x),
 	|x, y, z, w| parachain_subxt::api::tx().ibc().transfer(x, CurrencyId(y), z, w),
 	|x| parachain_subxt::api::tx().sudo().sudo(x),

--- a/scripts/hyperspace.Dockerfile
+++ b/scripts/hyperspace.Dockerfile
@@ -1,4 +1,4 @@
-FROM paritytech/ci-unified:bullseye-1.71.0 as builder
+FROM paritytech/ci-unified:bullseye-1.71.0-v20230727 as builder
 
 WORKDIR /code
 

--- a/scripts/hyperspace.Dockerfile
+++ b/scripts/hyperspace.Dockerfile
@@ -1,4 +1,4 @@
-FROM paritytech/ci-unified:latest as builder
+FROM paritytech/ci-unified:bullseye-1.71.0 as builder
 
 WORKDIR /code
 

--- a/scripts/hyperspace.Dockerfile
+++ b/scripts/hyperspace.Dockerfile
@@ -1,4 +1,4 @@
-FROM paritytech/ci-linux:production as builder
+FROM paritytech/ci-unified:latest as builder
 
 WORKDIR /code
 

--- a/scripts/parachain.Dockerfile
+++ b/scripts/parachain.Dockerfile
@@ -1,4 +1,4 @@
-FROM paritytech/ci-linux:production as build
+FROM paritytech/ci-unified:latest as build
 
 WORKDIR /code
 

--- a/scripts/parachain.Dockerfile
+++ b/scripts/parachain.Dockerfile
@@ -1,4 +1,4 @@
-FROM paritytech/ci-unified:bullseye-1.71.0 as build
+FROM paritytech/ci-unified:bullseye-1.71.0-v20230727 as build
 
 WORKDIR /code
 

--- a/scripts/parachain.Dockerfile
+++ b/scripts/parachain.Dockerfile
@@ -1,4 +1,4 @@
-FROM paritytech/ci-unified:latest as build
+FROM paritytech/ci-unified:bullseye-1.71.0 as build
 
 WORKDIR /code
 


### PR DESCRIPTION
Goal of this PR is to change docker image for ci jobs from:
`ci-linux:production` to `ci-unified:latest`

Issue: https://github.com/ComposableFi/centauri/issues/371

Using `:latest` tag: https://github.com/paritytech/scripts/tree/master/dockerfiles/ci-unified#latest-tag as this is equivalent to `:production`, which we used before.
