### PR TITLE
fix if statement to not go in XCM memo construction if substrate field is None

### DIFF
--- a/contracts/pallet-ibc/src/ics20/mod.rs
+++ b/contracts/pallet-ibc/src/ics20/mod.rs
@@ -668,7 +668,7 @@ pub enum MemoType {
 
 impl Forward {
 	pub fn get_memo(&self) -> Result<MemoType, Ics20Error> {
-		if !self.substrate.is_none() {
+		if self.substrate.unwrap_or_default() {
 			let xcm = MemoXcm { receiver: self.receiver.clone(), para_id: self.para_id.clone() };
 			return Ok(MemoType::XCM(xcm))
 		}


### PR DESCRIPTION
The previous version always works because composable always specify `None` for `substrate` memo field.
But once `composable` memo conversion was changed the `Substrate` field become false instead of None. 

