### PR TITLE
Remove-rate-limit

### DIFF
--- a/contracts/pallet-ibc/src/ics20/mod.rs
+++ b/contracts/pallet-ibc/src/ics20/mod.rs
@@ -49,23 +49,6 @@ pub type Ics20TransferMsg = ibc::applications::transfer::msgs::transfer::MsgTran
 	ibc::applications::transfer::Coin<ibc::applications::transfer::PrefixedDenom>,
 >;
 
-#[derive(Debug, Clone, Copy)]
-pub enum FlowType {
-	Transfer,
-	Deliver,
-}
-
-pub trait Ics20RateLimiter {
-	#[allow(clippy::result_unit_err)]
-	fn allow(msg: &Ics20TransferMsg, flow_type: FlowType) -> Result<(), ()>;
-}
-
-impl Ics20RateLimiter for frame_support::traits::Everything {
-	fn allow(_msg: &Ics20TransferMsg, _flow_type: FlowType) -> Result<(), ()> {
-		Ok(())
-	}
-}
-
 #[derive(Clone, Eq, Debug, PartialEq)]
 pub struct IbcModule<T: Config>(PhantomData<T>);
 
@@ -254,8 +237,6 @@ where
 					timeout_height: packet.timeout_height,
 					timeout_timestamp: packet.timeout_timestamp,
 				};
-				T::Ics20RateLimiter::allow(&msg, FlowType::Deliver)
-					.map_err(|_| Ics04Error::implementation_specific("rate limiter".to_string()))?;
 				let amount = packet_data.token.amount.as_u256();
 				u128::try_from(amount)
 					.map_err(|e| Ics04Error::implementation_specific(format!("{e:?}")))?;

--- a/contracts/pallet-ibc/src/ics20/mod.rs
+++ b/contracts/pallet-ibc/src/ics20/mod.rs
@@ -227,16 +227,6 @@ where
 					Ics04Error::implementation_specific("Failed to parse token denom".to_string())
 				})?;
 
-				let msg = Ics20TransferMsg {
-					source_port: packet.source_port.clone(),
-					memo: packet_data.memo.clone(),
-					sender: packet_data.sender.clone(),
-					receiver: packet_data.receiver.clone(),
-					source_channel: packet.source_channel,
-					token,
-					timeout_height: packet.timeout_height,
-					timeout_timestamp: packet.timeout_timestamp,
-				};
 				let amount = packet_data.token.amount.as_u256();
 				u128::try_from(amount)
 					.map_err(|e| Ics04Error::implementation_specific(format!("{e:?}")))?;

--- a/contracts/pallet-ibc/src/lib.rs
+++ b/contracts/pallet-ibc/src/lib.rs
@@ -133,10 +133,7 @@ pub mod weight;
 
 pub use weight::WeightInfo;
 
-use crate::{
-	ics20::{FlowType, Ics20RateLimiter},
-	ics20_fee::FlatFeeConverter,
-};
+use crate::ics20_fee::FlatFeeConverter;
 
 #[frame_support::pallet]
 pub mod pallet {
@@ -265,7 +262,6 @@ pub mod pallet {
 		type IbcAccountId: Into<AccountId32>;
 		type TransferOrigin: EnsureOrigin<Self::RuntimeOrigin, Success = Self::IbcAccountId>;
 		type RelayerOrigin: EnsureOrigin<Self::RuntimeOrigin, Success = Self::AccountId>;
-		type Ics20RateLimiter: Ics20RateLimiter;
 		/// Handle Ics20 Memo
 		type HandleMemo: HandleMemo<Self> + Default;
 		/// Memo Message types supported by the runtime
@@ -976,8 +972,6 @@ pub mod pallet {
 				memo: memo.map(|memo| memo.to_string()).unwrap_or_default(),
 			};
 
-			T::Ics20RateLimiter::allow(&msg, FlowType::Transfer)
-				.map_err(|_| Error::<T>::RateLimiter)?;
 			let is_sender_source = is_sender_chain_source(
 				msg.source_port.clone(),
 				msg.source_channel,

--- a/contracts/pallet-ibc/src/mock.rs
+++ b/contracts/pallet-ibc/src/mock.rs
@@ -241,7 +241,6 @@ impl Config for Test {
 	type MemoMessage = alloc::string::String;
 	type IsReceiveEnabled = sp_core::ConstBool<true>;
 	type IsSendEnabled = sp_core::ConstBool<true>;
-	type Ics20RateLimiter = Everything;
 	type FeeAccount = FeeAccount;
 	type CleanUpPacketsPeriod = CleanUpPacketsPeriod;
 	type ServiceChargeOut = ServiceCharge;

--- a/utils/parachain-node/runtime/src/lib.rs
+++ b/utils/parachain-node/runtime/src/lib.rs
@@ -745,7 +745,6 @@ impl pallet_ibc::Config for Runtime {
 	type PalletPrefix = IbcTriePrefix;
 	type LightClientProtocol = GRANDPA;
 	type IbcAccountId = Self::AccountId;
-	type Ics20RateLimiter = Everything;
 	type FeeAccount = FeeAccount;
 	type CleanUpPacketsPeriod = CleanUpPacketsPeriod;
 	type ServiceChargeOut = IbcIcs20ServiceCharge;


### PR DESCRIPTION
Rate limit has been enforced on Centauri using
a better strategy than this hard-coded naive one.

We are then removing this one.