### PR TITLE
Ensure target block headers are within votes ancestries

### DIFF
--- a/hyperspace/parachain/src/finality_protocol.rs
+++ b/hyperspace/parachain/src/finality_protocol.rs
@@ -518,6 +518,23 @@ where
 		}
 	}
 
+	// Sometimes the returned justification doesn't contain the header for the target block
+	// in the votes ancestry, so we need to fetch it manually
+	if !justification
+		.votes_ancestries
+		.iter()
+		.any(|h| h.number().into() == justification.commit.target_number as u64)
+	{
+		let header = prover
+			.relay_client
+			.rpc()
+			.header(Some(justification.commit.target_hash.into()))
+			.await
+			.unwrap()
+			.unwrap();
+		justification.votes_ancestries.push(header);
+	}
+
 	let justification = justification;
 
 	// fetch the latest finalized parachain header

--- a/hyperspace/parachain/src/finality_protocol.rs
+++ b/hyperspace/parachain/src/finality_protocol.rs
@@ -520,10 +520,11 @@ where
 
 	// Sometimes the returned justification doesn't contain the header for the target block
 	// in the votes ancestry, so we need to fetch it manually
-	if !justification
-		.votes_ancestries
-		.iter()
-		.any(|h| h.number().into() == justification.commit.target_number as u64)
+	if !justification.votes_ancestries.is_empty() &&
+		!justification
+			.votes_ancestries
+			.iter()
+			.any(|h| h.number().into() == justification.commit.target_number as u64)
 	{
 		let header = prover
 			.relay_client


### PR DESCRIPTION
Added necessary logic to fetch and include the target block header manually in the event it is not found within the returned justification's votes ancestries. This resolves potential issues where the target block header may not be immediately available within the ancestries of the justification