### PR TITLE
Fix timestamp issue

### DIFF
--- a/light-clients/common/src/lib.rs
+++ b/light-clients/common/src/lib.rs
@@ -194,9 +194,9 @@ pub fn decode_timestamp_extrinsic(ext: &Vec<u8>) -> Result<u64, anyhow::Error> {
 	// https://github.com/paritytech/substrate/blob/d602397a0bbb24b5d627795b797259a44a5e29e9/primitives/trie/src/lib.rs#L99-L101
 	// Decoding from the [2..] because the timestamp inmherent has two extra bytes before the call
 	// that represents the call length and the extrinsic version.
-	let (_, _, timestamp): (u8, u8, Compact<u64>) = codec::Decode::decode(&mut &ext[2..])
+	let ret: Compact<u64> = codec::Decode::decode(&mut &ext[ext.len() - 7..])
 		.map_err(|err| anyhow!("Failed to decode extrinsic: {err}"))?;
-	Ok(timestamp.into())
+	Ok(ret.into())
 }
 
 /// This will verify that the connection delay has elapsed for a given [`ibc::Height`]

--- a/light-clients/ics10-grandpa/src/consensus_state.rs
+++ b/light-clients/ics10-grandpa/src/consensus_state.rs
@@ -81,8 +81,7 @@ impl ConsensusState {
 		let duration = core::time::Duration::from_millis(timestamp);
 		let timestamp = Timestamp::from_nanoseconds(duration.as_nanos().saturated_into::<u64>())?
 			.into_tm_time()
-			.ok_or_else(|| anyhow!(format!("Error decoding Timestamp, timestamp cannot be zero: timestamp: {}, &parachain_header_proof.extrinsic: {:?}", timestamp, &parachain_header_proof.extrinsic)))?;
-
+			.ok_or_else(|| anyhow!("Error decoding Timestamp, timestamp cannot be zero"))?;
 		Ok((
 			Height::new(para_id as u64, parachain_header.number as u64),
 			Self { root: root.into(), timestamp },


### PR DESCRIPTION
fix `decode_timestamp_extrinsic` to decode timestamp directly into `Compact<u64>`